### PR TITLE
fix(SE-187): improve auth flow when no user record in db

### DIFF
--- a/apps/web/src/components/organisms/Layout/RootLayout.tsx
+++ b/apps/web/src/components/organisms/Layout/RootLayout.tsx
@@ -25,7 +25,7 @@ export interface RootLayoutProps {
   children: ReactNode
   heading?: string
   backLink?: ReactNode
-  user: Session['user']
+  user?: Session['user']
 }
 
 export function RootLayout({ children, backLink, heading = SERVICE_NAME, user }: RootLayoutProps) {
@@ -42,7 +42,7 @@ export function RootLayout({ children, backLink, heading = SERVICE_NAME, user }:
   }, [session])
 
   useEffect(() => {
-    if (idle && session) {
+    if (idle && session?.idleTimeout) {
       logger.info(`user is idle after ${session.idleTimeout} seconds - logging out`)
       void Router.push(SIGN_OUT_PAGE)
     }

--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -176,21 +176,26 @@ export const authOptions: AuthOptions = {
 
         return session
       } catch (error) {
-        logger.error('NextAuth session callback exception')
+        logger.error('NextAuth session callback exception for %s', token.user.email)
         logger.error(error)
         return session
       }
     },
     async signIn({ user: { email } }) {
       if (email) {
-        await prismaClient.user.update({
-          where: {
-            email,
-          },
-          data: {
-            lastLogin: new Date(),
-          },
-        })
+        try {
+          await prismaClient.user.update({
+            where: {
+              email,
+            },
+            data: {
+              lastLogin: new Date(),
+            },
+          })
+        } catch (error) {
+          logger.error('NextAuth signIn callback exception for %s', email)
+          logger.error(error)
+        }
       }
       return true
     },

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { Container } from '@nihr-ui/frontend'
+import { logger } from '@nihr-ui/logger'
 import type { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next'
 import { getServerSession } from 'next-auth/next'
 import type { ReactElement } from 'react'
@@ -42,6 +43,13 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       }
     }
 
+    if (!session.user.id) {
+      logger.error('Session missing required user data. Check this IDG user has a corresponding User record.')
+      return {
+        props: {},
+      }
+    }
+
     const {
       user: { roles, organisations },
     } = session
@@ -68,6 +76,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       },
     }
   } catch (error) {
+    logger.error(error)
     return {
       redirect: {
         destination: ERROR_PAGE_500,


### PR DESCRIPTION
https://nihr.atlassian.net/browse/SE-187

- Added graceful handling for when an IDG user logs in with no associated User record in the SE database
- Fixed two instances where errors could be swallowed during the auth flow
- Fixed idle timeout triggering unintentionally on auth unhappy paths

Before:

![before](https://github.com/PA-NIHR-CRN/sponsor-engagement-web/assets/135131279/8d7a4e1f-e674-4ed6-ba27-38d330608a97)

After:

![after](https://github.com/PA-NIHR-CRN/sponsor-engagement-web/assets/135131279/e6770913-a28a-4953-86a1-9ef2134c5e0d)
