### PR TITLE
feat: add Idg post firstName and lastName

### DIFF
--- a/apps/web/src/pages/api/forms/registration.ts
+++ b/apps/web/src/pages/api/forms/registration.ts
@@ -27,7 +27,7 @@ export default async (req: ExtendedNextApiRequest, res: NextApiResponse) => {
       throw new Error('Wrong method')
     }
 
-    const { password, registrationToken } = registrationSchema.parse(req.body)
+    const { password, registrationToken, firstName, lastName } = registrationSchema.parse(req.body)
 
     // Find contact information associated with the given registrationToken
     const user = await prismaClient.user.findFirst({
@@ -41,8 +41,13 @@ export default async (req: ExtendedNextApiRequest, res: NextApiResponse) => {
       throw new Error(`No email found associated with the registrationToken ${registrationToken}`)
     }
 
+    const givenName = firstName
+    const familyName = lastName
+
     // Create a new user in IDG
     const createUserResponse = await authService.createUser({
+      givenName,
+      familyName,
       password,
       emails: [user.email],
     })

--- a/apps/web/src/pages/register/index.tsx
+++ b/apps/web/src/pages/register/index.tsx
@@ -79,6 +79,22 @@ export default function Register({ query, registrationToken }: RegisterProps) {
             <Fieldset legend="Set a password for your NIHR Identity Gateway account">
               <TextInput
                 className="govuk-input--width-20 flex-grow"
+                defaultValue={defaultValues?.firstName}
+                errors={errors}
+                label="First name"
+                type="text"
+                {...register('firstName')}
+              />
+              <TextInput
+                className="govuk-input--width-20 flex-grow"
+                defaultValue={defaultValues?.lastName}
+                errors={errors}
+                label="Last name"
+                type="text"
+                {...register('lastName')}
+              />
+              <TextInput
+                className="govuk-input--width-20 flex-grow"
                 defaultValue={defaultValues?.password}
                 errors={errors}
                 label="Create your password"

--- a/apps/web/src/utils/schemas/registration.schema.ts
+++ b/apps/web/src/utils/schemas/registration.schema.ts
@@ -7,6 +7,8 @@ export type RegistrationInputs = z.infer<typeof registrationSchema>
 export const registrationSchema = z
   .object({
     registrationToken: z.string(),
+    firstName: z.string().min(1, { message: 'First name is required' }),
+    lastName: z.string().min(1, { message: 'Last name is required' }),
     password: z
       .string()
       .min(PASSWORD_MIN_LENGTH, { message: 'Enter a minimum of 12 characters' })


### PR DESCRIPTION
Include the user's first name and last name when registering a new account with Idg.

This is to fix an issue whereby users trying to reset their passwords were getting an error, due to not having a first and last name on their Idg account