### PR TITLE
SE-166: Save evals to SE

### DIFF
--- a/apps/web/src/@types/studies.ts
+++ b/apps/web/src/@types/studies.ts
@@ -14,10 +14,9 @@ export interface Study {
   PlannedClosureToRecruitmentDate: string
   ActualClosureToRecruitmentDate: string
   EstimatedReopeningDate: string | null
-  UkRecruitmentTarget: number
+  TotalRecruitmentToDate: number
   UkRecruitmentTargetToDate: number
-  StudyEvaluations: any[]
-  ChangeHistory: any[]
+  StudyEvaluationCategories: StudyEvaluationCategory[]
 }
 
 export enum StudyRecordStatus {

--- a/apps/web/src/lib/studies.spec.ts
+++ b/apps/web/src/lib/studies.spec.ts
@@ -1,10 +1,11 @@
-import { Prisma, type Study } from 'database'
+import type { Study } from 'database'
+import { Prisma } from 'database'
 import { Mock } from 'ts-mockery'
 
 import { prismaMock } from '../__mocks__/prisma'
 import { StudySponsorOrganisationRoleRTSIdentifier } from '../constants'
 import type { UpdateStudyInput } from './studies'
-import { getStudiesForOrgs, getStudyById, updateStudy } from './studies'
+import { getStudiesForOrgs, getStudyById, updateEvaluationCategories, updateStudy } from './studies'
 
 describe('getStudiesForOrgs', () => {
   const mockStudies = [Mock.of<Study>({ id: 1, title: 'Study 1' }), Mock.of<Study>({ id: 2, title: 'Study 2' })]
@@ -299,7 +300,7 @@ describe('getStudyById', () => {
   })
 })
 
-describe('UpdateStudy', () => {
+describe('updateStudy', () => {
   type StudyWithOrganisations = Prisma.StudyGetPayload<{
     include: {
       organisations: {
@@ -363,6 +364,9 @@ describe('UpdateStudy', () => {
               organisationRole: true,
             },
           },
+          evaluationCategories: {
+            select: { id: true, indicatorValue: true },
+          },
         },
       })
     )
@@ -377,6 +381,191 @@ describe('UpdateStudy', () => {
     prismaMock.study.update.mockRejectedValueOnce(new Error(errorMessage))
 
     const result = await updateStudy(studyId, mockStudyInputs)
+    expect(result).toEqual({ data: null, error: errorMessage })
+  })
+})
+
+describe('updateEvaluationCategories', () => {
+  const mockStudyId = 9282382
+
+  const mockEvaluationCategoriesResponse = Mock.of<Prisma.StudyEvaluationCategoryGetPayload<undefined>>({
+    studyId: 18108,
+    indicatorType: 'Missed milestone',
+    indicatorValue: 'Study is past planned opening date',
+    sampleSize: 3,
+    totalRecruitmentToDate: 0,
+    plannedOpeningDate: new Date('2020-10-09T23:00:00.000Z'),
+    plannedClosureDate: new Date('2020-10-09T23:00:00.000Z'),
+    actualOpeningDate: new Date('2020-10-09T23:00:00.000Z'),
+    actualClosureDate: null,
+    expectedReopenDate: null,
+    createdAt: new Date('2020-10-09T23:00:00.000Z'),
+    updatedAt: new Date('2020-10-09T23:00:00.000Z'),
+    isDeleted: false,
+  })
+
+  it('correctly updates and returns an evaluation when no deletion is required and there is a single evaluation record', async () => {
+    prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce({
+      ...mockEvaluationCategoriesResponse,
+      id: 484022,
+    })
+
+    const result = await updateEvaluationCategories(mockStudyId, [mockEvaluationCategoriesResponse], [])
+
+    expect(result).toEqual({ data: [{ ...mockEvaluationCategoriesResponse, id: 484022 }], error: null })
+
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(1)
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          studyId_indicatorValue: {
+            studyId: mockStudyId,
+            indicatorValue: mockEvaluationCategoriesResponse.indicatorValue,
+          },
+        },
+        update: mockEvaluationCategoriesResponse,
+        create: mockEvaluationCategoriesResponse,
+      })
+    )
+
+    expect(prismaMock.studyEvaluationCategory.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('correctly updates and returns evaluations when no deletion is required and there are multiple evaluations', async () => {
+    const mockEvaluationCategoriesResponseTwo = Mock.of<Prisma.StudyEvaluationCategoryGetPayload<undefined>>({
+      studyId: 934834,
+      indicatorType: 'Missed milestone',
+      indicatorValue: 'Study is past planned opening date',
+      sampleSize: 3,
+      totalRecruitmentToDate: 0,
+      plannedOpeningDate: new Date('2020-10-09T23:00:00.000Z'),
+      plannedClosureDate: new Date('2020-10-09T23:00:00.000Z'),
+      actualOpeningDate: new Date('2020-10-09T23:00:00.000Z'),
+      actualClosureDate: null,
+      expectedReopenDate: null,
+      createdAt: new Date('2020-10-09T23:00:00.000Z'),
+      updatedAt: new Date('2020-10-09T23:00:00.000Z'),
+      isDeleted: false,
+    })
+
+    prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce({
+      ...mockEvaluationCategoriesResponse,
+      id: 484022,
+    })
+    prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce({
+      ...mockEvaluationCategoriesResponseTwo,
+      id: 484023,
+    })
+
+    const result = await updateEvaluationCategories(
+      mockStudyId,
+      [mockEvaluationCategoriesResponse, mockEvaluationCategoriesResponseTwo],
+      []
+    )
+
+    expect(result).toEqual({
+      data: [
+        { ...mockEvaluationCategoriesResponse, id: 484022 },
+        {
+          ...mockEvaluationCategoriesResponseTwo,
+          id: 484023,
+        },
+      ],
+      error: null,
+    })
+
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(2)
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          studyId_indicatorValue: {
+            studyId: mockStudyId,
+            indicatorValue: mockEvaluationCategoriesResponse.indicatorValue,
+          },
+        },
+        update: mockEvaluationCategoriesResponse,
+        create: mockEvaluationCategoriesResponse,
+      })
+    )
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          studyId_indicatorValue: {
+            studyId: mockStudyId,
+            indicatorValue: mockEvaluationCategoriesResponseTwo.indicatorValue,
+          },
+        },
+        update: mockEvaluationCategoriesResponseTwo,
+        create: mockEvaluationCategoriesResponseTwo,
+      })
+    )
+
+    expect(prismaMock.studyEvaluationCategory.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('correctly updates and deletes a given evaluation, when deletion is required', async () => {
+    const studyEvalToDelete = 2323232
+
+    prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce({
+      ...mockEvaluationCategoriesResponse,
+      id: 484022,
+    })
+
+    const result = await updateEvaluationCategories(
+      mockStudyId,
+      [mockEvaluationCategoriesResponse],
+      [studyEvalToDelete]
+    )
+
+    expect(result).toEqual({ data: [{ ...mockEvaluationCategoriesResponse, id: 484022 }], error: null })
+
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(1)
+    expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          studyId_indicatorValue: {
+            studyId: mockStudyId,
+            indicatorValue: mockEvaluationCategoriesResponse.indicatorValue,
+          },
+        },
+        update: mockEvaluationCategoriesResponse,
+        create: mockEvaluationCategoriesResponse,
+      })
+    )
+
+    expect(prismaMock.studyEvaluationCategory.updateMany).toHaveBeenCalledTimes(1)
+    expect(prismaMock.studyEvaluationCategory.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: [studyEvalToDelete] }, isDeleted: false },
+        data: { isDeleted: true },
+      })
+    )
+  })
+
+  it('returns the correct error message when there is an error updating a study evaluation', async () => {
+    const errorMessage = 'Oh no, an error!'
+
+    prismaMock.studyEvaluationCategory.upsert.mockRejectedValueOnce(new Error(errorMessage))
+
+    const result = await updateEvaluationCategories(mockStudyId, [mockEvaluationCategoriesResponse], [])
+    expect(result).toEqual({ data: null, error: errorMessage })
+  })
+
+  it('returns the correct error message when there is an error deleting a study evaluation', async () => {
+    const studyEvalToDelete = 2323232
+    const errorMessage = 'Oh no, an error!'
+
+    prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce({
+      ...mockEvaluationCategoriesResponse,
+      id: 484022,
+    })
+    prismaMock.studyEvaluationCategory.updateMany.mockRejectedValueOnce(new Error(errorMessage))
+
+    const result = await updateEvaluationCategories(
+      mockStudyId,
+      [mockEvaluationCategoriesResponse],
+      [studyEvalToDelete]
+    )
     expect(result).toEqual({ data: null, error: errorMessage })
   })
 })

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -266,20 +266,18 @@ export const getStudiesForExport = async (organisationIds: number[]) => {
 
 export type UpdateStudyInput = Prisma.StudyUpdateInput
 
-export const mapCPMSStudyToPrismaStudy = (study: Study): UpdateStudyInput => {
-  return {
-    cpmsId: study.StudyId,
-    shortTitle: study.StudyShortName,
-    studyStatus: study.StudyStatus,
-    route: study.StudyRoute,
-    sampleSize: study.TotalRecruitmentToDate,
-    totalRecruitmentToDate: study.UkRecruitmentTargetToDate,
-    plannedOpeningDate: study.PlannedOpeningDate ? new Date(study.PlannedOpeningDate) : null,
-    plannedClosureDate: study.PlannedClosureToRecruitmentDate ? new Date(study.PlannedClosureToRecruitmentDate) : null,
-    actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
-    actualClosureDate: study.ActualClosureToRecruitmentDate ? new Date(study.ActualClosureToRecruitmentDate) : null,
-  }
-}
+export const mapCPMSStudyToPrismaStudy = (study: Study): UpdateStudyInput => ({
+  cpmsId: study.StudyId,
+  shortTitle: study.StudyShortName,
+  studyStatus: study.StudyStatus,
+  route: study.StudyRoute,
+  sampleSize: study.TotalRecruitmentToDate,
+  totalRecruitmentToDate: study.UkRecruitmentTargetToDate,
+  plannedOpeningDate: study.PlannedOpeningDate ? new Date(study.PlannedOpeningDate) : null,
+  plannedClosureDate: study.PlannedClosureToRecruitmentDate ? new Date(study.PlannedClosureToRecruitmentDate) : null,
+  actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
+  actualClosureDate: study.ActualClosureToRecruitmentDate ? new Date(study.ActualClosureToRecruitmentDate) : null,
+})
 
 export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) => {
   try {
@@ -326,51 +324,52 @@ export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) =
   }
 }
 
-export type UpdateStudyEvalInput = Prisma.StudyEvaluationCategoryUpdateInput
+export const mapCPMSStudyEvalToPrisma = (studyEvaluation: StudyEvaluationCategory) => ({
+  indicatorType: studyEvaluation.EvaluationCategoryType,
+  indicatorValue: studyEvaluation.EvaluationCategoryValue,
+  sampleSize: studyEvaluation.SampleSize,
+  totalRecruitmentToDate: studyEvaluation.TotalRecruitmentToDate,
+  plannedOpeningDate: studyEvaluation.PlannedRecruitmentStartDate
+    ? new Date(studyEvaluation.PlannedRecruitmentStartDate)
+    : null,
+  plannedClosureDate: studyEvaluation.PlannedRecruitmentEndDate
+    ? new Date(studyEvaluation.PlannedRecruitmentEndDate)
+    : null,
+  actualOpeningDate: studyEvaluation.ActualOpeningDate ? new Date(studyEvaluation.ActualOpeningDate) : null,
+  actualClosureDate: studyEvaluation.ActualClosureDate ? new Date(studyEvaluation.ActualClosureDate) : null,
+  expectedReopenDate: studyEvaluation.ExpectedReopenDate ? new Date(studyEvaluation.ExpectedReopenDate) : null,
+  isDeleted: false,
+})
 
 export const updateEvaluationCategories = async (
   studyId: number,
-  studyEvaluationsToUpsert: StudyEvaluationCategory[],
+  studyEvaluationsToUpsert: Prisma.StudyEvaluationCategoryCreateWithoutStudyInput[],
   studyEvaluationIdsToDelete: number[]
 ) => {
   try {
     // Add evaluation categories
     const evaluationCategoryInputs = studyEvaluationsToUpsert.map((category) => {
-      const evaluationCategoryData = {
-        studyId,
-        indicatorType: category.EvaluationCategoryType,
-        indicatorValue: category.EvaluationCategoryValue,
-        sampleSize: category.SampleSize,
-        totalRecruitmentToDate: category.TotalRecruitmentToDate,
-        plannedOpeningDate: category.PlannedRecruitmentStartDate
-          ? new Date(category.PlannedRecruitmentStartDate)
-          : null,
-        plannedClosureDate: category.PlannedRecruitmentEndDate ? new Date(category.PlannedRecruitmentEndDate) : null,
-        actualOpeningDate: category.ActualOpeningDate ? new Date(category.ActualOpeningDate) : null,
-        actualClosureDate: category.ActualClosureDate ? new Date(category.ActualClosureDate) : null,
-        expectedReopenDate: category.ExpectedReopenDate ? new Date(category.ExpectedReopenDate) : null,
-        isDeleted: false,
-      }
-
       return prismaClient.studyEvaluationCategory.upsert({
         where: {
           studyId_indicatorValue: {
             studyId,
-            indicatorValue: category.EvaluationCategoryValue,
+            indicatorValue: category.indicatorValue,
           },
         },
-        update: evaluationCategoryData,
-        create: evaluationCategoryData,
+        update: category,
+        create: { studyId, ...category },
       })
     })
 
     const evaluationCategories = await Promise.all(evaluationCategoryInputs)
 
     // Delete evaluation categories
-    await prismaClient.studyEvaluationCategory.updateMany({
-      where: { id: { in: studyEvaluationIdsToDelete }, isDeleted: false },
-      data: { isDeleted: true },
-    })
+    if (studyEvaluationIdsToDelete.length > 0) {
+      await prismaClient.studyEvaluationCategory.updateMany({
+        where: { id: { in: studyEvaluationIdsToDelete }, isDeleted: false },
+        data: { isDeleted: true },
+      })
+    }
 
     return { data: evaluationCategories, error: null }
   } catch (error) {

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -324,7 +324,7 @@ export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) =
   }
 }
 
-export const mapCPMSStudyEvalToPrisma = (studyEvaluation: StudyEvaluationCategory) => ({
+export const mapCPMSStudyEvalToPrismaEval = (studyEvaluation: StudyEvaluationCategory) => ({
   indicatorType: studyEvaluation.EvaluationCategoryType,
   indicatorValue: studyEvaluation.EvaluationCategoryValue,
   sampleSize: studyEvaluation.SampleSize,

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -21,7 +21,13 @@ import {
   studyStatuses,
 } from '@/constants/editStudyForm'
 import { getStudyByIdFromCPMS } from '@/lib/cpms/studies'
-import { getStudyById, mapCPMSStudyToPrismaStudy, updateEvaluationCategories, updateStudy } from '@/lib/studies'
+import {
+  getStudyById,
+  mapCPMSStudyEvalToPrisma,
+  mapCPMSStudyToPrismaStudy,
+  updateEvaluationCategories,
+  updateStudy,
+} from '@/lib/studies'
 import { mapStudyToStudyFormInput } from '@/utils/editStudyForm'
 import type { EditStudyInputs } from '@/utils/schemas'
 import { studySchema } from '@/utils/schemas'
@@ -288,9 +294,10 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     )
     .map(({ id }) => id)
 
+  const mappedStudyEvalsInCPMS = studyEvalsInCPMS.map((studyEval) => mapCPMSStudyEvalToPrisma(studyEval))
   const { data: updatedStudyEvals } = await updateEvaluationCategories(
     seStudyRecord.data.id,
-    studyEvalsInCPMS,
+    mappedStudyEvalsInCPMS,
     studyEvalIdsToDelete
   )
 

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -23,7 +23,7 @@ import {
 import { getStudyByIdFromCPMS } from '@/lib/cpms/studies'
 import {
   getStudyById,
-  mapCPMSStudyEvalToPrisma,
+  mapCPMSStudyEvalToPrismaEval,
   mapCPMSStudyToPrismaStudy,
   updateEvaluationCategories,
   updateStudy,
@@ -294,7 +294,7 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     )
     .map(({ id }) => id)
 
-  const mappedStudyEvalsInCPMS = studyEvalsInCPMS.map((studyEval) => mapCPMSStudyEvalToPrisma(studyEval))
+  const mappedStudyEvalsInCPMS = studyEvalsInCPMS.map((studyEval) => mapCPMSStudyEvalToPrismaEval(studyEval))
   const { data: updatedStudyEvals } = await updateEvaluationCategories(
     seStudyRecord.data.id,
     mappedStudyEvalsInCPMS,

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -21,7 +21,7 @@ import {
   studyStatuses,
 } from '@/constants/editStudyForm'
 import { getStudyByIdFromCPMS } from '@/lib/cpms/studies'
-import { getStudyById, mapCPMSStudyToPrismaStudy, updateStudy } from '@/lib/studies'
+import { getStudyById, mapCPMSStudyToPrismaStudy, updateEvaluationCategories, updateStudy } from '@/lib/studies'
 import { mapStudyToStudyFormInput } from '@/utils/editStudyForm'
 import type { EditStudyInputs } from '@/utils/schemas'
 import { studySchema } from '@/utils/schemas'
@@ -257,9 +257,8 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
       },
     }
   }
-  const { study: studyInCPMS } = await getStudyByIdFromCPMS(cpmsId)
+  const { study: studyInCPMS } = await getStudyByIdFromCPMS(Number(cpmsId))
 
-  // If there is an error fetching from CPMS, do we want to attempt to get from SE DB before redirecting to 500?
   if (!studyInCPMS) {
     return {
       redirect: {
@@ -278,10 +277,35 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     }
   }
 
+  const studyEvalsInCPMS = studyInCPMS.StudyEvaluationCategories
+  const currentStudyEvalsInSE = study.evaluationCategories
+
+  // Soft delete evaluations in SE that are no longer returned from CPMS
+  const studyEvalIdsToDelete = currentStudyEvalsInSE
+    .filter(
+      (seEval) =>
+        !studyEvalsInCPMS.some(({ EvaluationCategoryValue }) => EvaluationCategoryValue === seEval.indicatorValue)
+    )
+    .map(({ id }) => id)
+
+  const { data: updatedStudyEvals } = await updateEvaluationCategories(
+    seStudyRecord.data.id,
+    studyEvalsInCPMS,
+    studyEvalIdsToDelete
+  )
+
+  if (!updatedStudyEvals) {
+    return {
+      redirect: {
+        destination: '/500',
+      },
+    }
+  }
+
   return {
     props: {
       user: session.user,
-      study,
+      study: { ...study, evaluationCategories: updatedStudyEvals },
     },
   }
 })


### PR DESCRIPTION
This PR:

- saves evals from CPMS to SE
- soft deletes evals in SE that were not returned from CPMS