### PR TITLE
SE-166: Estimated reopening date

### DIFF
--- a/apps/ingest/src/ingest.ts
+++ b/apps/ingest/src/ingest.ts
@@ -48,6 +48,7 @@ const createStudies = async () => {
       plannedClosureDate: study.PlannedRecruitmentEndDate ? new Date(study.PlannedRecruitmentEndDate) : null,
       actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
       actualClosureDate: study.ActualClosureDate ? new Date(study.ActualClosureDate) : null,
+      estimatedReopeningDate: study.EstimatedReopeningDate ? new Date(study.EstimatedReopeningDate) : null,
       isDueAssessment: false,
       isDeleted: false,
     }

--- a/apps/ingest/src/mocks/studies.json
+++ b/apps/ingest/src/mocks/studies.json
@@ -21,6 +21,7 @@
         "PlannedRecruitmentEndDate": "2003-02-28T00:00:00",
         "ActualOpeningDate": "1991-09-01T00:00:00",
         "ActualClosureDate": "2003-02-28T00:00:00",
+        "EstimatedReopeningDate": "2003-02-28T00:00:00",
         "TotalRecruitmentToDate": 683,
         "StudyEvaluationCategories": [
           {

--- a/apps/ingest/src/tests/index.spec.ts
+++ b/apps/ingest/src/tests/index.spec.ts
@@ -101,6 +101,7 @@ describe('ingest', () => {
       plannedClosureDate: expect.any(Date),
       actualOpeningDate: expect.any(Date),
       actualClosureDate: expect.any(Date),
+      estimatedReopeningDate: expect.any(Date),
       isDeleted: false,
     }
 

--- a/apps/ingest/src/types.ts
+++ b/apps/ingest/src/types.ts
@@ -61,6 +61,7 @@ export interface Study {
   PlannedRecruitmentEndDate: null | string
   ActualOpeningDate: null | string
   ActualClosureDate: null | string
+  EstimatedReopeningDate: null | string
   StudyEvaluationCategories: StudyEvaluationCategory[]
   StudySponsors: StudySponsor[]
   StudyFunders: StudyFunder[]

--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -276,6 +276,10 @@ describe('EditStudy', () => {
       const actualClosingDateFieldset = screen.getByRole('group', { name: 'Actual closure to recruitment date' })
       expect(actualClosingDateFieldset).toBeInTheDocument()
 
+      // Form Input - Estimated reopening date
+      const estimatedReopeningDate = screen.getByRole('group', { name: 'Estimated reopening date' })
+      expect(estimatedReopeningDate).toBeInTheDocument()
+
       // Form Input - UK Recruitment target
       const ukRecruitmentTarget = screen.getByLabelText('UK recruitment target')
       expect(ukRecruitmentTarget).toBeInTheDocument()

--- a/apps/web/src/lib/studies.spec.ts
+++ b/apps/web/src/lib/studies.spec.ts
@@ -592,6 +592,7 @@ describe('mapCPMSStudyToSEStudy', () => {
     plannedClosureDate: new Date(mockCPMSStudy.PlannedClosureToRecruitmentDate),
     actualOpeningDate: new Date(mockCPMSStudy.ActualOpeningDate),
     actualClosureDate: new Date(mockCPMSStudy.ActualClosureToRecruitmentDate),
+    estimatedReopeningDate: new Date(mockCPMSStudy.EstimatedReopeningDate as string),
   }
 
   it('correctly maps data when all fields exist', () => {
@@ -606,6 +607,7 @@ describe('mapCPMSStudyToSEStudy', () => {
       PlannedClosureToRecruitmentDate: '',
       ActualOpeningDate: '',
       ActualClosureToRecruitmentDate: '',
+      EstimatedReopeningDate: '',
     })
     expect(result).toStrictEqual({
       ...mockMappedStudy,
@@ -613,6 +615,7 @@ describe('mapCPMSStudyToSEStudy', () => {
       actualOpeningDate: null,
       plannedClosureDate: null,
       plannedOpeningDate: null,
+      estimatedReopeningDate: null,
     })
   })
 })

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -337,7 +337,6 @@ export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) =
       },
     }
   } catch (error) {
-    console.log({ error })
     const errorMessage = getErrorMessage(error)
     return {
       data: null,

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -297,6 +297,7 @@ export const mapCPMSStudyToSEStudy = (study: Study): UpdateStudyInput => ({
   plannedClosureDate: study.PlannedClosureToRecruitmentDate ? new Date(study.PlannedClosureToRecruitmentDate) : null,
   actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
   actualClosureDate: study.ActualClosureToRecruitmentDate ? new Date(study.ActualClosureToRecruitmentDate) : null,
+  estimatedReopeningDate: study.EstimatedReopeningDate ? new Date(study.EstimatedReopeningDate) : null,
 })
 
 export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) => {
@@ -336,6 +337,7 @@ export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) =
       },
     }
   } catch (error) {
+    console.log({ error })
     const errorMessage = getErrorMessage(error)
     return {
       data: null,

--- a/apps/web/src/mocks/studies.ts
+++ b/apps/web/src/mocks/studies.ts
@@ -90,6 +90,7 @@ export const mockCPMSStudy = Mock.of<Study>({
   PlannedClosureToRecruitmentDate: '2003-02-28T00:00:00',
   ActualOpeningDate: '1991-09-01T00:00:00',
   ActualClosureToRecruitmentDate: '2003-02-28T00:00:00',
+  EstimatedReopeningDate: '2003-02-28T00:00:00',
   TotalRecruitmentToDate: 683,
   UkRecruitmentTargetToDate: 121,
   StudyEvaluationCategories: [

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -29,6 +29,7 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
       plannedOpeningDate,
       actualClosureDate,
       actualOpeningDate,
+      estimatedReopeningDate,
       ...studyData
     } = studySchema.parse(req.body)
 
@@ -38,6 +39,9 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
       ...(actualOpeningDate && { ActualOpeningDate: constructDateObjFromParts(actualOpeningDate) }),
       ...(plannedClosureDate && { PlannedClosureToRecruitmentDate: constructDateObjFromParts(plannedClosureDate) }),
       ...(actualClosureDate && { ActualClosureToRecruitmentDate: constructDateObjFromParts(actualClosureDate) }),
+      ...(estimatedReopeningDate && {
+        EstimatedReopeningDate: constructDateObjFromParts(estimatedReopeningDate),
+      }),
     })
 
     const requestUrl = `${CPMS_API_URL}/studies/${cpmsId}/engagement-info`

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -179,6 +179,27 @@ export default function EditStudy({ study }: EditStudyProps) {
                 }}
               />
 
+              {/* Estimated reopening date*/}
+              <Controller
+                control={control}
+                name="estimatedReopeningDate"
+                render={({ field }) => {
+                  const { value, onChange, ref, name } = field
+
+                  return (
+                    <DateInput
+                      disabled
+                      errors={{}}
+                      label="Estimated reopening date"
+                      name={name}
+                      onChange={onChange}
+                      ref={ref}
+                      value={value}
+                    />
+                  )
+                }}
+              />
+
               {/* UK recruitment target */}
               <TextInput
                 defaultValue={defaultValues?.recruitmentTarget}

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -121,7 +121,7 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
               <Table.Row>
                 <Table.CellHeader className="w-1/3">Planned opening date</Table.CellHeader>
                 <Table.Cell>
-                  {studyInCPMS.PlannedClosureToRecruitmentDate ? formatDate(studyInCPMS.PlannedOpeningDate) : '-'}
+                  {studyInCPMS.PlannedOpeningDate ? formatDate(studyInCPMS.PlannedOpeningDate) : '-'}
                 </Table.Cell>
               </Table.Row>
               <Table.Row>
@@ -141,7 +141,9 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
               <Table.Row>
                 <Table.CellHeader className="w-1/3">Actual closure to recruitment date</Table.CellHeader>
                 <Table.Cell>
-                  {studyInCPMS.ActualOpeningDate ? formatDate(studyInCPMS.ActualClosureToRecruitmentDate) : '-'}
+                  {studyInCPMS.ActualClosureToRecruitmentDate
+                    ? formatDate(studyInCPMS.ActualClosureToRecruitmentDate)
+                    : '-'}
                 </Table.Cell>
               </Table.Row>
               {studyInCPMS.StudyStatus === 'Suspended' && Boolean(studyInCPMS.StudyEvaluationCategories.length) && (

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -156,7 +156,7 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
               )}
 
               <Table.Row>
-                <Table.CellHeader className="w-1/3">
+                <Table.CellHeader className="w-1/3" data-testid="uk-recruitment-target-label">
                   {studyInCPMS.StudyRoute === 'Commercial'
                     ? 'UK recruitment target (excluding private sites)'
                     : 'UK recruitment target'}

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -12,5 +12,6 @@ export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditSt
   plannedClosureDate: constructDatePartsFromDate(study.plannedClosureDate),
   actualOpeningDate: constructDatePartsFromDate(study.actualOpeningDate),
   actualClosureDate: constructDatePartsFromDate(study.actualClosureDate),
+  estimatedReopeningDate: constructDatePartsFromDate(study.estimatedReopeningDate),
   furtherInformation: '', // TODO: is there a field for this
 })

--- a/apps/web/src/utils/schemas/study.schema.ts
+++ b/apps/web/src/utils/schemas/study.schema.ts
@@ -14,6 +14,7 @@ export const studySchema = z.object({
   actualOpeningDate: dateSchema.optional(),
   plannedClosureDate: dateSchema.optional(),
   actualClosureDate: dateSchema.optional(),
+  estimatedReopeningDate: dateSchema.optional(),
   recruitmentTarget: z.number().optional(),
   furtherInformation: z.string().optional(),
 })

--- a/packages/database/prisma/migrations/20240917085208_study_estimated_reopening_date/migration.sql
+++ b/packages/database/prisma/migrations/20240917085208_study_estimated_reopening_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Study` ADD COLUMN `estimatedReopeningDate` DATETIME(3) NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Study {
   plannedClosureDate         DateTime?
   actualOpeningDate          DateTime?
   actualClosureDate          DateTime?
+  estimatedReopeningDate     DateTime?
   totalRecruitmentToDate     Int?
   assessments                Assessment[]
   organisations              StudyOrganisation[]


### PR DESCRIPTION
This PR:

- adds estimated reopening date to the SE Study schema
- adds a field for this on the edit study form and sends it through to CPMS
- stores this value from CPMS into SE DB on edit/study details page load
- updates ingest to also store this value from CPMS into SE
- includes a fix for displaying dates on study details page

This has been tested against a local mysql server.