### PR TITLE
SE-181: Update total recruitment label

### DIFF
--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -166,7 +166,7 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
                 <Table.Cell>{studyInCPMS.SampleSize ?? '-'}</Table.Cell>
               </Table.Row>
               <Table.Row>
-                <Table.CellHeader className="w-1/3">
+                <Table.CellHeader className="w-1/3" data-testid="total-uk-recruitment-label">
                   {studyInCPMS.StudyRoute === 'Commercial'
                     ? 'Total UK recruitment to date (excluding private sites)'
                     : 'Total UK recruitment to date'}

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -166,7 +166,11 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
                 <Table.Cell>{studyInCPMS.SampleSize ?? '-'}</Table.Cell>
               </Table.Row>
               <Table.Row>
-                <Table.CellHeader className="w-1/3">Total UK recruitment to date</Table.CellHeader>
+                <Table.CellHeader className="w-1/3">
+                  {studyInCPMS.StudyRoute === 'Commercial'
+                    ? 'Total UK recruitment to date (excluding private sites)'
+                    : 'Total UK recruitment to date'}
+                </Table.CellHeader>
                 <Table.Cell>{studyInCPMS.TotalRecruitmentToDate ?? '-'}</Table.Cell>
               </Table.Row>
             </Table.Body>

--- a/packages/qa/pages/StudyDetailsPage.ts
+++ b/packages/qa/pages/StudyDetailsPage.ts
@@ -136,7 +136,7 @@ export default class StudyDetailsPage {
     // })
     this.tableUkTargetHeader = page.locator('th[data-testid="uk-recruitment-target-label"]')
     this.tableUkTargetValue = this.tableUkTargetHeader.locator('..').locator('td')
-    this.tableUkTotalHeader = page.locator('th[scope="row"]', { hasText: 'Total UK recruitment to date' })
+    this.tableUkTotalHeader = page.locator('th[data-testid="total-uk-recruitment-label"]')
     this.tableUkTotalValue = this.tableUkTotalHeader.locator('..').locator('td')
     this.tableEstimatedReopenDateHeader = page.locator('th[scope="row"]', { hasText: 'Estimated reopening date' })
     this.tableEstimatedReopenDateValue = this.tableEstimatedReopenDateHeader.locator('..').locator('td')
@@ -408,8 +408,13 @@ export default class StudyDetailsPage {
     }
   }
 
-  async assertUkTotal(expectedTotal: number) {
+  async assertUkTotal(expectedTotal: number, studyRoute: string) {
     await expect(this.tableUkTotalHeader).toBeVisible()
+    if (studyRoute === 'Non-commercial') {
+      await expect(this.tableUkTotalHeader).toHaveText('Total UK recruitment to date')
+    } else {
+      await expect(this.tableUkTotalHeader).toHaveText('Total UK recruitment to date (excluding private sites)')
+    }
     await expect(this.tableUkTotalValue).toBeVisible()
     await expect(this.tableUkTotalValue).toHaveText(expectedTotal.toString())
   }

--- a/packages/qa/tests/features/studyDetailsTests/studyDetailsSummaryTest.e2e.ts
+++ b/packages/qa/tests/features/studyDetailsTests/studyDetailsSummaryTest.e2e.ts
@@ -159,7 +159,10 @@ test.describe('Access Study Details Page and view Summary - @se_26', () => {
       await studyDetailsPage.assertUkTarget(studyProgressDetails[0].sampleSize, studyProgressDetails[0].route)
     })
     await test.step('And I can see the Studies UK Recruitment Total', async () => {
-      await studyDetailsPage.assertUkTotal(studyProgressDetails[0].totalRecruitmentToDate)
+      await studyDetailsPage.assertUkTotal(
+        studyProgressDetails[0].totalRecruitmentToDate,
+        studyProgressDetails[0].route
+      )
     })
   })
 
@@ -274,7 +277,10 @@ test.describe('Access Study Details Page and view Summary - @se_26', () => {
       )
     })
     await test.step('And I can see the Studies Network Recruitment Total', async () => {
-      await studyDetailsPage.assertUkTotal(nonCommStudyProgressDetails[0].totalRecruitmentToDate)
+      await studyDetailsPage.assertUkTotal(
+        nonCommStudyProgressDetails[0].totalRecruitmentToDate,
+        nonCommStudyProgressDetails[0].route
+      )
     })
   })
 })


### PR DESCRIPTION
This PR changes the total recruitment label text depending on if a study is a commercial one. 