### PR TITLE
SE-184: Call validate endpoint

### DIFF
--- a/apps/web/src/@types/studies.ts
+++ b/apps/web/src/@types/studies.ts
@@ -6,6 +6,21 @@ export interface CPMSStudyResponse {
   Result: Study
 }
 
+export enum StudyUpdateRoute {
+  Direct = 'Direct',
+  Proposed = 'Proposed',
+}
+
+export interface CPMSValidationResult {
+  StudyUpdateRoute: StudyUpdateRoute
+}
+
+export interface CPMSValidateStudyResponse {
+  Version: string
+  StatusCode: number
+  Result: CPMSValidationResult
+}
+
 export interface Study {
   Title: string
   StudyId: number

--- a/apps/web/src/__tests__/Study.spec.tsx
+++ b/apps/web/src/__tests__/Study.spec.tsx
@@ -415,23 +415,6 @@ describe('Study', () => {
       expect(rowHeader).toBeInTheDocument()
       expect(rowHeader.nextSibling).toHaveTextContent('-')
     })
-
-    test('Success banner shows after redirection from the assessment form', async () => {
-      await renderPage(undefined, '?success=1')
-
-      // Title
-      expect(
-        screen.getByRole('heading', { level: 2, name: `Study short title: ${mockCPMSStudy.StudyShortName}` })
-      ).toBeInTheDocument()
-
-      // Banner
-      const banner = screen.getByRole('alert', { name: 'Success' })
-      expect(within(banner).getByText('The study assessment was successfully saved')).toBeInTheDocument()
-      expect(within(banner).getByRole('link', { name: 'NIHR RDN support' })).toHaveAttribute('href', SUPPORT_PAGE)
-      expect(within(banner).getByRole('link', { name: 'NIHR RDN support' }).parentElement).toHaveTextContent(
-        'Request NIHR RDN support for this study.'
-      )
-    })
   })
 
   describe('Sponsor assessment history accordion', () => {
@@ -498,5 +481,34 @@ describe('Study', () => {
 
       expect(screen.getByText('Testing some further information')).toBeInTheDocument()
     })
+  })
+
+  describe('Success banner', () => {
+    test.each([
+      ['1', 'The study assessment was successfully saved'],
+      [
+        '2',
+        'Your study data changes have been received. These will now be reviewed by the appropriate team and applied to the study in due course. Until then, previous study data values will be displayed here.',
+      ],
+      [
+        '3',
+        'Your study data changes have been applied. All changes have been accepted by CPMS and do not require any manual review.',
+      ],
+    ])(
+      'should show the correct success message when success type is %s',
+      async (successType: string, successMessage: string) => {
+        await renderPage(undefined, `?success=${successType}`)
+
+        const banner = screen.getByRole('alert', { name: 'Success' })
+        expect(within(banner).getByText(successMessage)).toBeInTheDocument()
+
+        if (successType === '1') {
+          expect(within(banner).getByRole('link', { name: 'NIHR RDN support' })).toHaveAttribute('href', SUPPORT_PAGE)
+          expect(within(banner).getByRole('link', { name: 'NIHR RDN support' }).parentElement).toHaveTextContent(
+            'Request NIHR RDN support for this study.'
+          )
+        }
+      }
+    )
   })
 })

--- a/apps/web/src/constants/forms.ts
+++ b/apps/web/src/constants/forms.ts
@@ -11,3 +11,12 @@ export const FORM_ERRORS = {
   2: 'The email address you have entered already exists for a user assigned to this organisation, so the user has not been added',
   3: "The user has been assigned to the organisation, but the invite email has not been sent as the user's email domain is not in the allowed list for testing",
 } as Record<number, string>
+
+/**
+ * Success messages for different form submissions
+ */
+export const FORM_SUCCESS_MESSAGES = {
+  1: 'The study assessment was successfully saved',
+  2: 'Your study data changes have been received. These will now be reviewed by the appropriate team and applied to the study in due course. Until then, previous study data values will be displayed here.', // Proposed study updates
+  3: 'Your study data changes have been applied. All changes have been accepted by CPMS and do not require any manual review.', // Direct study updates
+} as Record<number, string>

--- a/apps/web/src/mocks/studies.ts
+++ b/apps/web/src/mocks/studies.ts
@@ -2,7 +2,12 @@ import { simpleFaker } from '@faker-js/faker'
 import type { Prisma } from 'database'
 import { Mock } from 'ts-mockery'
 
-import { type Study, StudySponsorOrganisationRole, StudySponsorOrganisationRoleRTSIdentifier } from '@/@types/studies'
+import type { CPMSValidationResult, Study } from '@/@types/studies'
+import {
+  StudySponsorOrganisationRole,
+  StudySponsorOrganisationRoleRTSIdentifier,
+  StudyUpdateRoute,
+} from '@/@types/studies'
 import type { StudyForExport } from '@/lib/studies'
 
 export const mockStudiesForExport = Array.from({ length: 3 }).map((_, index) =>
@@ -80,6 +85,10 @@ export const mockStudiesForExport = Array.from({ length: 3 }).map((_, index) =>
     },
   })
 )
+
+export const mockCPMSValidationResult = Mock.of<CPMSValidationResult>({
+  StudyUpdateRoute: StudyUpdateRoute.Direct,
+})
 
 export const mockCPMSStudy = Mock.of<Study>({
   StudyId: 622,

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -227,7 +227,7 @@ describe('/api/forms/editStudy', () => {
       expect(mockedPutAxios).not.toHaveBeenCalled()
     })
 
-    test('should redirect correctly when the request to create a studyUpdates entry fails', async () => {
+    test('should redirect correctly when the request to create an entry in the studyUpdates table fails', async () => {
       mockedPostAxios.mockResolvedValueOnce({ data: getMockValidateStudyResponse(StudyUpdateRoute.Direct) })
       prismaMock.studyUpdates.create.mockRejectedValueOnce(new Error(''))
 

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -8,6 +8,7 @@ import type { ReactElement } from 'react'
 import { AssessmentHistory, getAssessmentHistoryFromStudy, RequestSupport, StudyDetails } from '@/components/molecules'
 import { RootLayout } from '@/components/organisms'
 import { EDIT_STUDY_ROLE, Roles } from '@/constants'
+import { FORM_SUCCESS_MESSAGES } from '@/constants/forms'
 import { ASSESSMENT_PAGE, STUDIES_PAGE, SUPPORT_PAGE } from '@/constants/routes'
 import { getStudyByIdFromCPMS } from '@/lib/cpms/studies'
 import {
@@ -20,14 +21,18 @@ import {
 import { formatDate } from '@/utils/date'
 import { withServerSideProps } from '@/utils/withServerSideProps'
 
-const renderNotificationBanner = (success: boolean) =>
-  success ? (
-    <NotificationBanner heading="The study assessment was successfully saved" success>
-      Request{' '}
-      <Link className="govuk-notification-banner__link" href={SUPPORT_PAGE}>
-        NIHR RDN support
-      </Link>{' '}
-      for this study.
+const renderNotificationBanner = (success: string | undefined, showRequestSupportLink: boolean) =>
+  success || !Number.isNaN(Number(success)) ? (
+    <NotificationBanner heading={FORM_SUCCESS_MESSAGES[Number(success)]} success>
+      {showRequestSupportLink ? (
+        <>
+          Request{' '}
+          <Link className="govuk-notification-banner__link" href={SUPPORT_PAGE}>
+            NIHR RDN support
+          </Link>{' '}
+          for this study.
+        </>
+      ) : null}
     </NotificationBanner>
   ) : null
 
@@ -45,6 +50,7 @@ export type StudyProps = InferGetServerSidePropsType<typeof getServerSideProps>
 
 export default function Study({ user, study, studyInCPMS, assessments }: StudyProps) {
   const router = useRouter()
+  const successType = router.query.success as string
   const { organisationsByRole } = study
 
   const supportOrgName = organisationsByRole.CRO ?? organisationsByRole.CTU
@@ -56,7 +62,7 @@ export default function Study({ user, study, studyInCPMS, assessments }: StudyPr
       <NextSeo title={`Study Progress Review - ${studyInCPMS.StudyShortName}`} />
       <div className="lg:flex lg:gap-6">
         <div className="w-full">
-          {renderNotificationBanner(Boolean(router.query.success))}
+          {renderNotificationBanner(successType, successType === '1')}
 
           <h2 className="govuk-heading-l govuk-!-margin-bottom-1">
             <span className="govuk-visually-hidden">Study short title: </span>


### PR DESCRIPTION
This PR:
- calls the new validate study endpoint in CPMS
- uses the feature flag to control whether we treat the change as direct or proposed:
  feature flag is **disabled** -> study update type is always proposed (therefore, no call to CPMS)
  feature flag is **enabled** -> uses the response from the validate endpoint to determine the study update type 