### PR TITLE
Se-184: Fix date transformation

### DIFF
--- a/apps/web/src/utils/date.spec.ts
+++ b/apps/web/src/utils/date.spec.ts
@@ -38,6 +38,12 @@ describe('constructDateObjFromParts', () => {
     const result = constructDateObjFromParts(validDateParts)
     expect(result).toEqual(new Date('2021-02-15'))
   })
+
+  it.each(['year', 'month', 'day'])('should return undefined if %s is an empty string', (datePart: string) => {
+    const invalidDateParts = { year: '2021', month: '02', day: '01' }
+    const result = constructDateObjFromParts({ ...invalidDateParts, [datePart]: '' })
+    expect(result).toBeUndefined()
+  })
 })
 
 describe('constructDatePartsFromDate', () => {

--- a/apps/web/src/utils/date.ts
+++ b/apps/web/src/utils/date.ts
@@ -34,7 +34,11 @@ export const constructDatePartsFromDate = (date?: Date | null) => {
 export const constructDateObjFromParts = (dateParts?: DateInputValue) => {
   if (!dateParts) return undefined
 
-  if (Object.values(dateParts).find((value) => Number.isNaN(Number(value)))) {
+  const containsAllValidNumbers = Object.values(dateParts).every(
+    (val: string) => !Number.isNaN(Number(val)) && val.trim() !== ''
+  )
+
+  if (!containsAllValidNumbers) {
     return undefined
   }
 


### PR DESCRIPTION
Bug:
When removing a date, the form would throw a fatal error.

Why:
The year/month/day field would be set as an empty string when date is removed. When we construct a date from date parts, we check if every field is a number and `Number('')` is 0 so is a valid number. 

Fix:
We also check if the field is an empty string. 