### PR TITLE
SE-184: Save StudyStatusGroup

### DIFF
--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -288,17 +288,21 @@ export const mapCPMSStatusToFormStatus = (cpmsStatus: string): string => {
   return statusMap[cpmsStatus] || cpmsStatus
 }
 
-export const mapFormStatusToCPMSStatus = (status: string): string => {
+export const mapFormStatusToCPMSStatus = (newStatus: string, currentStatus: string): string => {
+  const isCurrentStatusOpenWithRecruitment = currentStatus === 'Open, With Recruitment'
+
   const statusMap = {
     [FormStudyStatus.InSetup]: 'In Setup',
     [FormStudyStatus.Closed]: 'Closed to Recruitment, Follow Up Complete',
     [FormStudyStatus.ClosedFollowUp]: 'Closed to Recruitment, In Follow Up',
     [FormStudyStatus.OpenToRecruitment]: 'Open to Recruitment',
-    [FormStudyStatus.Suspended]: 'Suspended (from Open, With Recruitment)',
+    [FormStudyStatus.Suspended]: isCurrentStatusOpenWithRecruitment
+      ? 'Suspended (from Open, With Recruitment)'
+      : 'Suspended (from Open to Recruitment)',
     [FormStudyStatus.Withdrawn]: 'Withdrawn During Setup',
   }
 
-  return statusMap[status] || status
+  return statusMap[newStatus] || newStatus
 }
 
 export const mapCPMSStudyToSEStudy = (study: Study): UpdateStudyInput => ({

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -279,7 +279,7 @@ export const mapCPMSStatusToFormStatus = (cpmsStatus: string): string => {
     'Closed to Recruitment': 'Closed',
     'Closed to Recruitment, In Follow Up': 'Closed, in follow up',
     'Closed to Recruitment, Follow Up Complete': 'Closed',
-    Suspended: 'Suspended',
+    'Suspended (from Open, With Recruitment)': 'Suspended',
     'Suspended (from Open to Recruitment)': 'Suspended',
     'Withdrawn in Pre-Setup': 'Withdrawn',
     'Withdrawn During Setup': 'Withdrawn',
@@ -294,7 +294,7 @@ export const mapFormStatusToCPMSStatus = (status: string): string => {
     [FormStudyStatus.Closed]: 'Closed to Recruitment, Follow Up Complete',
     [FormStudyStatus.ClosedFollowUp]: 'Closed to Recruitment, In Follow Up',
     [FormStudyStatus.OpenToRecruitment]: 'Open to Recruitment',
-    [FormStudyStatus.Suspended]: 'Suspended (from Open to Recruitment)',
+    [FormStudyStatus.Suspended]: 'Suspended (from Open, With Recruitment)',
     [FormStudyStatus.Withdrawn]: 'Withdrawn During Setup',
   }
 

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -280,6 +280,7 @@ export const mapCPMSStatusToFormStatus = (cpmsStatus: string): string => {
     'Closed to Recruitment, In Follow Up': 'Closed, in follow up',
     'Closed to Recruitment, Follow Up Complete': 'Closed',
     Suspended: 'Suspended',
+    'Suspended (from Open to Recruitment)': 'Suspended',
     'Withdrawn in Pre-Setup': 'Withdrawn',
     'Withdrawn During Setup': 'Withdrawn',
   }

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -89,6 +89,7 @@ const mockStudyUpdateResponse = {
   id: 3232,
   studyId: mockStudyId,
   studyStatus: mockCPMSStudy.StudyStatus,
+  studyStatusGroup: 'Suspended',
   ukRecruitmentTarget: mockCPMSStudy.SampleSize,
   comment: '',
   plannedOpeningDate: new Date(mockCPMSStudy.PlannedOpeningDate as string),
@@ -99,7 +100,8 @@ const mockStudyUpdateResponse = {
 }
 
 const getMockStudyUpdateInput = (isDirect: boolean) => ({
-  studyStatus: body.status,
+  ...(isDirect && { studyStatus: body.status }),
+  studyStatusGroup: mockStudyUpdateResponse.studyStatusGroup,
   plannedOpeningDate: mockStudyUpdateResponse.plannedOpeningDate,
   actualOpeningDate: mockStudyUpdateResponse.actualOpeningDate,
   plannedClosureToRecruitmentDate: mockStudyUpdateResponse.plannedClosureToRecruitmentDate,

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -100,7 +100,7 @@ const mockStudyUpdateResponse = {
 }
 
 const getMockStudyUpdateInput = (isDirect: boolean) => ({
-  ...(isDirect && { studyStatus: body.status }),
+  studyStatus: isDirect ? body.status : null,
   studyStatusGroup: mockStudyUpdateResponse.studyStatusGroup,
   plannedOpeningDate: mockStudyUpdateResponse.plannedOpeningDate,
   actualOpeningDate: mockStudyUpdateResponse.actualOpeningDate,

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -46,7 +46,7 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
     const formattedEstimatedReopeningDate = constructDateObjFromParts(studyData.estimatedReopeningDate)
 
     const studyUpdate: Prisma.StudyUpdatesCreateInput = {
-      ...(isDirectUpdate && { studyStatus: studyData.status }),
+      studyStatus: isDirectUpdate ? studyData.status : null,
       studyStatusGroup: mapCPMSStatusToFormStatus(studyData.status),
       plannedOpeningDate: formattedPlannedOpeningDate,
       actualOpeningDate: formattedActualOpeningDate,

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -5,6 +5,7 @@ import { StudyUpdateRoute } from '@/@types/studies'
 import { Roles, StudyUpdateType } from '@/constants'
 import { mapEditStudyInputToCPMSStudy, updateStudyInCPMS, validateStudyUpdate } from '@/lib/cpms/studies'
 import { prismaClient } from '@/lib/prisma'
+import { mapCPMSStatusToFormStatus } from '@/lib/studies'
 import { constructDateObjFromParts } from '@/utils/date'
 import type { EditStudyInputs } from '@/utils/schemas'
 import { studySchema } from '@/utils/schemas'
@@ -45,7 +46,8 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
     const formattedEstimatedReopeningDate = constructDateObjFromParts(studyData.estimatedReopeningDate)
 
     const studyUpdate: Prisma.StudyUpdatesCreateInput = {
-      studyStatus: studyData.status,
+      ...(isDirectUpdate && { studyStatus: studyData.status }),
+      studyStatusGroup: mapCPMSStatusToFormStatus(studyData.status),
       plannedOpeningDate: formattedPlannedOpeningDate,
       actualOpeningDate: formattedActualOpeningDate,
       plannedClosureToRecruitmentDate: formattedPlannedClosureDate,

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -102,7 +102,8 @@ export default function EditStudy({ study }: EditStudyProps) {
 
                   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
                     if (e.target.defaultValue) {
-                      const mappedStatus = mapFormStatusToCPMSStatus(e.target.defaultValue)
+                      const originalStatus = study.studyStatus
+                      const mappedStatus = mapFormStatusToCPMSStatus(e.target.defaultValue, originalStatus)
                       onChange(mappedStatus)
                     }
                   }

--- a/packages/database/prisma/migrations/20240924120515_study_updates_status/migration.sql
+++ b/packages/database/prisma/migrations/20240924120515_study_updates_status/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `studyStatusGroup` to the `StudyUpdates` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `StudyUpdates` ADD COLUMN `studyStatusGroup` VARCHAR(191) NOT NULL,
+    MODIFY `studyStatus` VARCHAR(191) NULL;

--- a/packages/database/prisma/migrations/20240924120515_study_updates_status/migration.sql
+++ b/packages/database/prisma/migrations/20240924120515_study_updates_status/migration.sql
@@ -4,6 +4,10 @@
   - Added the required column `studyStatusGroup` to the `StudyUpdates` table without a default value. This is not possible if the table is not empty.
 
 */
+
+-- DeleteRows
+TRUNCATE `StudyUpdates`;
+
 -- AlterTable
 ALTER TABLE `StudyUpdates` ADD COLUMN `studyStatusGroup` VARCHAR(191) NOT NULL,
     MODIFY `studyStatus` VARCHAR(191) NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -213,7 +213,8 @@ model StudyUpdates {
   id                              Int                   @id @default(autoincrement())
   study                           Study                 @relation(fields: [studyId], references: [id])
   studyId                         Int
-  studyStatus                     String
+  studyStatus                     String?
+  studyStatusGroup                String
   plannedOpeningDate              DateTime?
   actualOpeningDate               DateTime?
   plannedClosureToRecruitmentDate DateTime?


### PR DESCRIPTION
This PR: 

- adds a new field to the StudyUpdates table named `StudyStatusGroup` which is now mandatory (migration file includes deletion of records in that table)
- makes the existing `StudyStatus` field within this table optional

If proposed change, mapped CPMS status gets sent to validate endpoint but we only save form status in SE.
If direct change, mapped CPMS status get sent to validate endpoint AND saved in SE alongside form status.