### PR TITLE
SE-166: Remove input hints

### DIFF
--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -244,11 +244,10 @@ describe('EditStudy', () => {
       const statusFieldset = screen.getByRole('radiogroup', { name: 'Study status' })
       expect(statusFieldset).toBeInTheDocument()
 
-      // TODO: Why does accessible description for first element use parent label
-      // expect(within(statusFieldset).getByLabelText('In setup')).toBeInTheDocument()
-      // expect(within(statusFieldset).getByLabelText('In setup')).toHaveAccessibleDescription(
-      //   'Not yet open to recruitment.'
-      // )
+      expect(within(statusFieldset).getByLabelText('In setup')).toBeInTheDocument()
+      expect(within(statusFieldset).getByLabelText('In setup')).toHaveAccessibleDescription(
+        'Not yet open to recruitment.'
+      )
 
       expect(within(statusFieldset).getByLabelText('Open to recruitment')).toBeInTheDocument()
       expect(within(statusFieldset).getByLabelText('Open to recruitment')).toHaveAccessibleDescription(
@@ -298,9 +297,6 @@ describe('EditStudy', () => {
       // Form Input - UK Recruitment target
       const ukRecruitmentTarget = screen.getByLabelText('UK recruitment target')
       expect(ukRecruitmentTarget).toBeInTheDocument()
-      expect(ukRecruitmentTarget).toHaveAccessibleDescription(
-        'Changes to the UK recruitment target will be committed to CPMS after manual review.'
-      )
 
       // Form Input - Further information
       const furtherInformation = screen.getByLabelText('Further information')

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -129,7 +129,6 @@ export default function EditStudy({ study }: EditStudyProps) {
                     <RadioGroup
                       defaultValue={mappedSEStatusValue}
                       errors={{}}
-                      hint="Changes to the study status will be committed to CPMS after manual review."
                       label="Study status"
                       labelSize="m"
                       name={name}
@@ -248,7 +247,6 @@ export default function EditStudy({ study }: EditStudyProps) {
               <TextInput
                 defaultValue={defaultValues?.recruitmentTarget}
                 errors={{}}
-                hint="Changes to the UK recruitment target will be committed to CPMS after manual review. "
                 inputClassName="govuk-input--width-10"
                 label="UK recruitment target"
                 labelSize="m"


### PR DESCRIPTION
This PR removes the hints for uk recruitment target and status.
