### PR TITLE
SE-183: Add mandatory date fields logic

### DIFF
--- a/apps/web/src/@types/studies.ts
+++ b/apps/web/src/@types/studies.ts
@@ -51,13 +51,23 @@ export enum StudyRecordStatus {
 }
 
 export enum Status {
-  ClosedToRecruitmentFollowUpComplete = 'Closed to Recruitment, Follow Up Complete',
-  ClosedToRecruitmentInFollowUp = 'Closed to Recruitment, In Follow Up',
-  ClosedToRecruitmentNoFollowUp = 'Closed to Recruitment, No Follow Up',
+  PreSetup = 'Pre-Setup',
+  InSetup = 'In Setup',
+  InSetupPendingNHSPermission = 'In Setup, Pending NHS Permission',
+  InSetupApprovalReceived = 'In Setup, Approval Received',
+  InSetupPendingApproval = 'In Setup, Pending Approval',
   InSetupNHSPermissionReceived = 'In Setup, NHS Permission Received',
+  OpenToRecruitment = 'Open to Recruitment',
   OpenWithRecruitment = 'Open, With Recruitment',
+  ClosedToRecruitment = 'Closed to Recruitment',
+  ClosedToRecruitmentInFollowUp = 'Closed to Recruitment, In Follow Up',
+  ClosedToRecruitmentFollowUpComplete = 'Closed to Recruitment, Follow Up Complete',
+  ClosedToRecruitmentNoFollowUp = 'Closed to Recruitment, No Follow Up',
+  SuspendedFromOpenWithRecruitment = 'Suspended (from Open, With Recruitment)',
+  SuspendedFromOpenToRecruitment = 'Suspended (from Open to Recruitment)',
   Suspended = 'Suspended',
   WithdrawnDuringSetup = 'Withdrawn During Setup',
+  WithdrawnInPreSetup = 'Withdrawn in Pre-Setup',
 }
 
 export enum StudyStatus {

--- a/apps/web/src/__tests__/Study.spec.tsx
+++ b/apps/web/src/__tests__/Study.spec.tsx
@@ -330,7 +330,7 @@ describe('Study', () => {
         `${mappedCPMSStudyEvals[0].indicatorValue}, ${mappedCPMSStudyEvals[1].indicatorValue}`,
         '1 January 2001',
         '1 January 2001',
-        '1 January 2001',
+        '2 January 2001',
         '1 January 2001',
         '28 February 2003',
         `${mockStudy.sampleSize}`,

--- a/apps/web/src/constants/editStudyForm.ts
+++ b/apps/web/src/constants/editStudyForm.ts
@@ -1,3 +1,5 @@
+import type { DateFieldName } from '@/utils/schemas'
+
 export const PAGE_TITLE = 'Update study data'
 export const GENERIC_STUDIES_GUIDANCE_TEXT =
   'Changes to the study status, the key dates and recruitment targets will be communicated to RDN, where possible, your changes will update the study record automatically in CPMS, other changes might be subject to review by the RDN team.'
@@ -56,3 +58,39 @@ export const studyStatuses = [
  * Max amount of characters for furtherInformation text
  */
 export const FURTHER_INFO_MAX_CHARACTERS = 500
+
+export const fieldNameToLabelMapping: Record<keyof DateFieldName, string> = {
+  plannedOpeningDate: 'Planned opening to recruitment date',
+  actualOpeningDate: 'Actual opening to recruitment date',
+  plannedClosureDate: 'Planned closure to recruitment date',
+  actualClosureDate: 'Actual closure to recruitment date',
+  estimatedReopeningDate: 'Estimated reopening date',
+}
+
+export type DateRestrictions = 'requiredPast' | 'requiredCurrent' | 'requiredFuture'
+
+/**
+ * Date validation rules and dependencies
+ */
+export const dateValidationRules: Record<
+  keyof DateFieldName,
+  { restrictions: DateRestrictions[]; dependencies: { fieldName: keyof DateFieldName; requiredAfter?: boolean }[] }
+> = {
+  plannedOpeningDate: { restrictions: [], dependencies: [] },
+  actualOpeningDate: { restrictions: ['requiredPast', 'requiredCurrent'], dependencies: [] },
+  plannedClosureDate: {
+    restrictions: [],
+    dependencies: [
+      {
+        fieldName: 'plannedOpeningDate',
+        requiredAfter: true,
+      },
+      {
+        fieldName: 'actualOpeningDate',
+        requiredAfter: true,
+      },
+    ],
+  },
+  actualClosureDate: { restrictions: ['requiredPast', 'requiredCurrent'], dependencies: [] },
+  estimatedReopeningDate: { restrictions: ['requiredFuture'], dependencies: [] },
+}

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -1,4 +1,5 @@
 import type { Study, StudyEvaluationCategory } from '@/@types/studies'
+import { Status as CPMSStatus } from '@/@types/studies'
 import { FormStudyStatus } from '@/constants/editStudyForm'
 import { getErrorMessage } from '@/utils/error'
 
@@ -283,37 +284,38 @@ export type UpdateStudyInput = Prisma.StudyUpdateInput
 
 export const mapCPMSStatusToFormStatus = (cpmsStatus: string): string => {
   const statusMap: Record<string, string> = {
-    'Pre-Setup': 'In setup',
-    'In Setup': 'In setup',
-    'In Setup, Pending NHS Permission': 'In setup',
-    'In Setup, Approval Received': 'In setup',
-    'In Setup, Pending Approval': 'In setup',
-    'Open to Recruitment': 'Open to recruitment',
-    'Open, With Recruitment': 'Open to recruitment',
-    'Closed to Recruitment': 'Closed',
-    'Closed to Recruitment, In Follow Up': 'Closed, in follow up',
-    'Closed to Recruitment, Follow Up Complete': 'Closed',
-    'Suspended (from Open, With Recruitment)': 'Suspended',
-    'Suspended (from Open to Recruitment)': 'Suspended',
-    'Withdrawn in Pre-Setup': 'Withdrawn',
-    'Withdrawn During Setup': 'Withdrawn',
+    [CPMSStatus.PreSetup]: FormStudyStatus.InSetup,
+    [CPMSStatus.InSetup]: FormStudyStatus.InSetup,
+    [CPMSStatus.InSetupPendingNHSPermission]: FormStudyStatus.InSetup,
+    [CPMSStatus.InSetupApprovalReceived]: FormStudyStatus.InSetup,
+    [CPMSStatus.InSetupPendingApproval]: FormStudyStatus.InSetup,
+    [CPMSStatus.InSetupNHSPermissionReceived]: FormStudyStatus.InSetup,
+    [CPMSStatus.OpenToRecruitment]: FormStudyStatus.OpenToRecruitment,
+    [CPMSStatus.OpenWithRecruitment]: FormStudyStatus.OpenToRecruitment,
+    [CPMSStatus.ClosedToRecruitment]: FormStudyStatus.Closed,
+    [CPMSStatus.ClosedToRecruitmentInFollowUp]: FormStudyStatus.ClosedFollowUp,
+    [CPMSStatus.ClosedToRecruitmentFollowUpComplete]: FormStudyStatus.Closed,
+    [CPMSStatus.SuspendedFromOpenWithRecruitment]: FormStudyStatus.Suspended,
+    [CPMSStatus.SuspendedFromOpenToRecruitment]: FormStudyStatus.Suspended,
+    [CPMSStatus.WithdrawnInPreSetup]: FormStudyStatus.Withdrawn,
+    [CPMSStatus.WithdrawnDuringSetup]: FormStudyStatus.Withdrawn,
   }
 
   return statusMap[cpmsStatus] || cpmsStatus
 }
 
 export const mapFormStatusToCPMSStatus = (newStatus: string, currentStatus: string): string => {
-  const isCurrentStatusOpenWithRecruitment = currentStatus === 'Open, With Recruitment'
+  const isCurrentStatusOpenWithRecruitment = currentStatus === (CPMSStatus.OpenWithRecruitment as string)
 
   const statusMap = {
-    [FormStudyStatus.InSetup]: 'In Setup',
-    [FormStudyStatus.Closed]: 'Closed to Recruitment, Follow Up Complete',
-    [FormStudyStatus.ClosedFollowUp]: 'Closed to Recruitment, In Follow Up',
-    [FormStudyStatus.OpenToRecruitment]: 'Open to Recruitment',
+    [FormStudyStatus.InSetup]: CPMSStatus.InSetup,
+    [FormStudyStatus.Closed]: CPMSStatus.ClosedToRecruitmentFollowUpComplete,
+    [FormStudyStatus.ClosedFollowUp]: CPMSStatus.ClosedToRecruitmentInFollowUp,
+    [FormStudyStatus.OpenToRecruitment]: CPMSStatus.OpenToRecruitment,
     [FormStudyStatus.Suspended]: isCurrentStatusOpenWithRecruitment
-      ? 'Suspended (from Open, With Recruitment)'
-      : 'Suspended (from Open to Recruitment)',
-    [FormStudyStatus.Withdrawn]: 'Withdrawn During Setup',
+      ? CPMSStatus.SuspendedFromOpenWithRecruitment
+      : CPMSStatus.SuspendedFromOpenToRecruitment,
+    [FormStudyStatus.Withdrawn]: CPMSStatus.WithdrawnDuringSetup,
   }
 
   return statusMap[newStatus] || newStatus

--- a/apps/web/src/mocks/studies.ts
+++ b/apps/web/src/mocks/studies.ts
@@ -228,7 +228,7 @@ export const mockStudyWithRelations = Mock.of<StudyWithRelations>({
   chiefInvestigatorLastName: 'Smith',
   managingSpeciality: '',
   plannedOpeningDate: new Date('2001-01-01'),
-  plannedClosureDate: new Date('2001-01-01'),
+  plannedClosureDate: new Date('2001-01-02'),
   actualOpeningDate: new Date('2001-01-01'),
   actualClosureDate: new Date('2001-01-01'),
   totalRecruitmentToDate: 999,

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs'
 import { z } from 'zod'
 
+import { dateValidationRules, fieldNameToLabelMapping, FormStudyStatus } from '@/constants/editStudyForm'
+import { mapCPMSStatusToFormStatus } from '@/lib/studies'
 import type { EditStudyProps } from '@/pages/studies/[studyId]/edit'
 
 import { constructDatePartsFromDate } from './date'
@@ -9,6 +11,7 @@ import type { DateFieldName, EditStudyInputs } from './schemas'
 export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditStudyInputs => ({
   studyId: study.id,
   status: study.studyStatus,
+  originalStatus: study.studyStatus,
   recruitmentTarget: study.sampleSize ?? undefined,
   cpmsId: study.cpmsId.toString(),
   plannedOpeningDate: constructDatePartsFromDate(study.plannedOpeningDate),
@@ -19,37 +22,42 @@ export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditSt
   furtherInformation: '', // TODO: is there a field for this
 })
 
-const fieldNameToLabelMapping: Record<keyof DateFieldName, string> = {
-  plannedOpeningDate: 'Planned opening to recruitment date',
-  actualOpeningDate: 'Actual opening to recruitment date',
-  plannedClosureDate: 'Planned closure to recruitment date',
-  actualClosureDate: 'Actual closure to recruitment date',
-  estimatedReopeningDate: 'Estimated reopening date',
-}
-
-type DateRestrictions = 'requiredPast' | 'requiredCurrent' | 'requiredFuture'
-
-const dateValidationRules: Record<
-  keyof DateFieldName,
-  { restrictions: DateRestrictions[]; dependencies: { fieldName: keyof DateFieldName; requiredAfter?: boolean }[] }
-> = {
-  plannedOpeningDate: { restrictions: [], dependencies: [] },
-  actualOpeningDate: { restrictions: ['requiredPast', 'requiredCurrent'], dependencies: [] },
-  plannedClosureDate: {
-    restrictions: [],
-    dependencies: [
-      {
-        fieldName: 'plannedOpeningDate',
-        requiredAfter: true,
-      },
-      {
-        fieldName: 'actualOpeningDate',
-        requiredAfter: true,
-      },
+/**
+ * Mapping to see which date fields are mandatory given a status
+ */
+const mapStatusToMandatoryDateFields = (previousStatus: string | null, newStatus: string) => {
+  const mandatoryDateFieldsByStatus: Record<string, (keyof DateFieldName)[]> = {
+    [FormStudyStatus.InSetup]: ['plannedOpeningDate', 'plannedClosureDate'],
+    [FormStudyStatus.OpenToRecruitment]: ['plannedOpeningDate', 'actualOpeningDate', 'plannedClosureDate'],
+    [FormStudyStatus.Suspended]: [
+      'plannedOpeningDate',
+      'actualOpeningDate',
+      'plannedClosureDate',
+      'estimatedReopeningDate',
     ],
-  },
-  actualClosureDate: { restrictions: ['requiredPast', 'requiredCurrent'], dependencies: [] },
-  estimatedReopeningDate: { restrictions: ['requiredFuture'], dependencies: [] },
+    [FormStudyStatus.Withdrawn]: ['plannedOpeningDate', 'plannedClosureDate'],
+    [FormStudyStatus.Closed]: ['plannedOpeningDate', 'actualOpeningDate', 'plannedClosureDate', 'actualClosureDate'],
+    [FormStudyStatus.ClosedFollowUp]: [
+      'plannedOpeningDate',
+      'actualOpeningDate',
+      'plannedClosureDate',
+      'actualClosureDate',
+    ],
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- status might not exist in object
+  const mandatoryDates = mandatoryDateFieldsByStatus[newStatus] || []
+
+  // Exceptions - there are a small amount of scenarios that relies on the previous status
+  if (
+    (previousStatus === (FormStudyStatus.InSetup as string) && newStatus === (FormStudyStatus.Suspended as string)) ||
+    (previousStatus === (FormStudyStatus.Suspended as string) &&
+      newStatus === (FormStudyStatus.OpenToRecruitment as string))
+  ) {
+    return mandatoryDates.filter((value) => value !== 'actualOpeningDate')
+  }
+
+  return mandatoryDates
 }
 
 /**
@@ -57,13 +65,25 @@ const dateValidationRules: Record<
  */
 const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, values: EditStudyInputs) => {
   const value = values[fieldName]
+  const currentStatus = mapCPMSStatusToFormStatus(values.status)
+  const previousStatus = values.originalStatus ? mapCPMSStatusToFormStatus(values.originalStatus) : null
   const label = fieldNameToLabelMapping[fieldName]
   const requiredPast = dateValidationRules[fieldName].restrictions.includes('requiredPast')
   const requiredCurrent = dateValidationRules[fieldName].restrictions.includes('requiredCurrent')
   const requiredFuture = dateValidationRules[fieldName].restrictions.includes('requiredFuture')
 
-  // If there does not exist a single date part, the value will be null
-  if (!value) return
+  if (!value) {
+    // Status based validation
+    if (mapStatusToMandatoryDateFields(previousStatus, currentStatus).includes(fieldName)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${fieldNameToLabelMapping[fieldName]} is a mandatory field`,
+        path: [fieldName],
+      })
+    }
+
+    return
+  }
 
   // Basic date validation
   if (Number(value.day) < 1 || Number(value.day) > 31) {
@@ -131,8 +151,6 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
           message: `${label} must be after ${specifiedDateLabel}`,
           path: [fieldName],
         })
-
-        z.NEVER
       }
     })
   }

--- a/apps/web/src/utils/schemas/study.schema.ts
+++ b/apps/web/src/utils/schemas/study.schema.ts
@@ -12,6 +12,7 @@ export const studySchema = z
   .object({
     studyId: z.number(),
     cpmsId: z.string(),
+    originalStatus: z.string().optional().nullable(),
     status: z.string(),
     plannedOpeningDate: dateSchema.optional().nullable(),
     actualOpeningDate: dateSchema.optional().nullable(),


### PR DESCRIPTION
This PR:
- updates the Status enum for CPMS statuses and uses it for the mappings
- adds in logic for mandatory date fields. Most of them all rely on the current status, however there are two exceptions which rely on what the previous status was

