### PR TITLE
Se-183: Update date validation 

### DIFF
--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -536,7 +536,7 @@ describe('EditStudy', () => {
         ).toBeInTheDocument()
       })
 
-      it.each(['-e', '-3', '19999999'])(
+      it.each(['19999999'])(
         'should display an error message when UK recruitment target has an invalid value',
         async (value: string) => {
           await renderPage()

--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -74,7 +74,6 @@ const removeDateField = async (label: string) => {
 
     expect(dateField).toBeInTheDocument()
 
-    await userEvent.click(dateField)
     await userEvent.clear(dateField)
   })
 
@@ -382,7 +381,7 @@ describe('EditStudy', () => {
 
   describe('Client side validation', () => {
     describe('should display an error on submit ', () => {
-      it.each(['Day', 'Month', 'Day'])('when a date field includes an invalid %s', async (datePart: string) => {
+      it.each(['Day', 'Month', 'Year'])('when a date field includes an invalid %s', async (datePart: string) => {
         await renderPage()
 
         const plannedOpenDateFieldset = screen.getByRole('group', { name: 'Planned opening to recruitment date' })
@@ -396,9 +395,34 @@ describe('EditStudy', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Update' }))
 
         // Error message
+        const errorMessage =
+          datePart === 'Year'
+            ? 'Year must include 4 numbers'
+            : `Planned opening to recruitment date requires a valid ${datePart.toLowerCase()}`
+
+        const alert = screen.getByRole('alert')
+        expect(within(alert).getByText(errorMessage)).toBeInTheDocument()
+
+        // Invalid field
+        expect(datePartField).toHaveAttribute('aria-invalid', 'true')
+      })
+
+      it.each(['Day', 'Month', 'Year'])('when a date does not include a %s', async (datePart: string) => {
+        await renderPage()
+
+        const plannedOpenDateFieldset = screen.getByRole('group', { name: 'Planned opening to recruitment date' })
+        expect(plannedOpenDateFieldset).toBeInTheDocument()
+        const datePartField = within(plannedOpenDateFieldset).getByLabelText(datePart)
+        expect(datePartField).toBeInTheDocument()
+
+        await userEvent.clear(datePartField)
+
+        await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+        // Error message
         const alert = screen.getByRole('alert')
         expect(
-          within(alert).getByText(`Planned opening to recruitment date requires a valid ${datePart.toLowerCase()}`)
+          within(alert).getByText(`Planned opening to recruitment date must include a ${datePart.toLowerCase()}`)
         ).toBeInTheDocument()
 
         // Invalid field

--- a/apps/web/src/components/atoms/Form/DateInput/DateInput.spec.tsx
+++ b/apps/web/src/components/atoms/Form/DateInput/DateInput.spec.tsx
@@ -30,19 +30,19 @@ test('renders three inputs with correct attributes and no error', () => {
   const dayInput = getByLabelText('Day')
   expect(dayInput).toBeInTheDocument()
   expect(dayInput).toHaveAttribute('name', `${name}-day`)
-  expect(dayInput).toHaveValue(null)
+  expect(dayInput).toHaveValue('')
 
   // Month input field
   const monthInput = getByLabelText('Month')
   expect(monthInput).toBeInTheDocument()
   expect(monthInput).toHaveAttribute('name', `${name}-month`)
-  expect(monthInput).toHaveValue(null)
+  expect(monthInput).toHaveValue('')
 
   // Year input field
   const yearInput = getByLabelText('Year')
   expect(yearInput).toBeInTheDocument()
   expect(yearInput).toHaveAttribute('name', `${name}-year`)
-  expect(yearInput).toHaveValue(null)
+  expect(yearInput).toHaveValue('')
 
   // Error
   const errorElement = queryByRole('alert')
@@ -58,17 +58,17 @@ test('renders three inputs with correct value', () => {
   // Day input field value
   const dayInput = getByLabelText('Day')
   expect(dayInput).toBeInTheDocument()
-  expect(dayInput).toHaveValue(Number(value.day))
+  expect(dayInput).toHaveValue(value.day)
 
   // Month input field value
   const monthInput = getByLabelText('Month')
   expect(monthInput).toBeInTheDocument()
-  expect(monthInput).toHaveValue(Number(value.month))
+  expect(monthInput).toHaveValue(value.month)
 
   // Year input field value
   const yearInput = getByLabelText('Year')
   expect(yearInput).toBeInTheDocument()
-  expect(yearInput).toHaveValue(Number(value.year))
+  expect(yearInput).toHaveValue(value.year)
 })
 
 test.each(['Day', 'Month', 'Year'])('renders correctly with field level errors', (dateField: string) => {

--- a/apps/web/src/components/atoms/Form/DateInput/DateInput.tsx
+++ b/apps/web/src/components/atoms/Form/DateInput/DateInput.tsx
@@ -33,9 +33,11 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const handleInputChange = (event: React.FormEvent<HTMLInputElement>, type: keyof DateInputValue) => {
       const { value: inputValue } = event.currentTarget
 
+      const valueWithNumericsOnly = inputValue.replace(/\D/g, '')
+
       const newDate = {
         ...value,
-        [type]: inputValue,
+        [type]: valueWithNumericsOnly,
       }
 
       onChange(newDate)
@@ -81,7 +83,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 }}
                 ref={ref}
                 required={required}
-                type="number"
+                type="text"
                 value={value.day}
                 {...rest}
                 disabled={disabled}
@@ -101,7 +103,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 }}
                 ref={ref}
                 required={required}
-                type="number"
+                type="text"
                 value={value.month}
                 {...rest}
                 disabled={disabled}
@@ -121,7 +123,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 }}
                 ref={ref}
                 required={required}
-                type="number"
+                type="text"
                 value={value.year}
                 {...rest}
                 disabled={disabled}

--- a/apps/web/src/components/atoms/Form/DateInput/DateInput.tsx
+++ b/apps/web/src/components/atoms/Form/DateInput/DateInput.tsx
@@ -88,6 +88,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 {...rest}
                 disabled={disabled}
                 id={`${rest.name}-day`}
+                inputMode="numeric"
                 name={`${rest.name}-day`}
               />
             </div>
@@ -108,6 +109,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 {...rest}
                 disabled={disabled}
                 id={`${rest.name}-month`}
+                inputMode="numeric"
                 name={`${rest.name}-month`}
               />
             </div>
@@ -128,6 +130,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 {...rest}
                 disabled={disabled}
                 id={`${rest.name}-year`}
+                inputMode="numeric"
                 name={`${rest.name}-year`}
               />
             </div>

--- a/apps/web/src/lib/cpms/studies.spec.ts
+++ b/apps/web/src/lib/cpms/studies.spec.ts
@@ -279,7 +279,7 @@ describe('mapEditStudyInputToCPMSStudy', () => {
       month: '02',
       year: '2003',
     },
-    recruitmentTarget: mockCPMSStudy.SampleSize ?? undefined,
+    recruitmentTarget: mockCPMSStudy.SampleSize?.toString() ?? undefined,
     furtherInformation: '',
   }
 

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -90,7 +90,7 @@ const body: EditStudyInputs = {
     month: '02',
     year: nextYearValue.toString(),
   },
-  recruitmentTarget: mockCPMSStudy.SampleSize ?? undefined,
+  recruitmentTarget: mockCPMSStudy.SampleSize?.toString() ?? undefined,
   furtherInformation: '',
 }
 

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -268,14 +268,27 @@ export default function EditStudy({ study }: EditStudyProps) {
               />
 
               {/* UK recruitment target */}
-              <TextInput
-                defaultValue={defaultValues?.recruitmentTarget}
-                errors={errors}
-                inputClassName="govuk-input--width-10"
-                label="UK recruitment target"
-                labelSize="m"
-                type="number"
-                {...register('recruitmentTarget', { valueAsNumber: true })}
+              <Controller
+                control={control}
+                name="recruitmentTarget"
+                render={({ field }) => {
+                  const { onChange, ...rest } = field
+
+                  return (
+                    <TextInput
+                      defaultValue={defaultValues?.recruitmentTarget}
+                      errors={errors}
+                      inputClassName="govuk-input--width-10"
+                      label="UK recruitment target"
+                      labelSize="m"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        const inputWithNumericsOnly = e.target.value.replace(/\D/g, '')
+                        onChange(inputWithNumericsOnly)
+                      }}
+                      {...rest}
+                    />
+                  )
+                }}
               />
 
               {/* Further information */}

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -276,7 +276,6 @@ export default function EditStudy({ study }: EditStudyProps) {
 
                   return (
                     <TextInput
-                      defaultValue={defaultValues?.recruitmentTarget}
                       errors={errors}
                       inputClassName="govuk-input--width-10"
                       label="UK recruitment target"

--- a/apps/web/src/utils/date.ts
+++ b/apps/web/src/utils/date.ts
@@ -46,4 +46,26 @@ export const constructDateObjFromParts = (dateParts?: DateInputValue | null) => 
   return new Date(`${Number(year)}-${Number(month)}-${Number(day)}`)
 }
 
+/**
+ * Checks to see if all date parts in type DateInputValue is empty
+ */
 export const areAllDatePartsEmpty = (dateParts: DateInputValue) => Object.values(dateParts).every((val) => val === '')
+
+/**
+ * Gets the maximum amount of days within a given month - takes into consideration leap years
+ */
+export const getDaysInMonth = (month: number, year?: number) => {
+  // month values - 0 to 11
+  switch (month) {
+    case 1:
+      if (!year) return 28
+      return (year % 4 === 0 && year % 100) || year % 400 === 0 ? 29 : 28
+    case 8:
+    case 3:
+    case 5:
+    case 10:
+      return 30
+    default:
+      return 31
+  }
+}

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -95,13 +95,13 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
   } else if (!value.month) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `${label} must include month`,
+      message: `${label} must include a month`,
       path: [`${fieldName}-month`],
     })
   } else if (!value.year) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `${label} must include year`,
+      message: `${label} must include a year`,
       path: [`${fieldName}-year`],
     })
   }
@@ -125,7 +125,7 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
   } else if (value.year.length !== 4) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `${label} must include 4 numbers`,
+      message: 'Year must include 4 numbers',
       path: [`${fieldName}-year`],
     })
 

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -12,7 +12,7 @@ export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditSt
   studyId: study.id,
   status: study.studyStatus,
   originalStatus: study.studyStatus,
-  recruitmentTarget: study.sampleSize ?? undefined,
+  recruitmentTarget: study.sampleSize?.toString() ?? undefined,
   cpmsId: study.cpmsId.toString(),
   plannedOpeningDate: constructDatePartsFromDate(study.plannedOpeningDate),
   plannedClosureDate: constructDatePartsFromDate(study.plannedClosureDate),

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -5,7 +5,7 @@ import { dateValidationRules, fieldNameToLabelMapping, FormStudyStatus } from '@
 import { mapCPMSStatusToFormStatus } from '@/lib/studies'
 import type { EditStudyProps } from '@/pages/studies/[studyId]/edit'
 
-import { constructDatePartsFromDate } from './date'
+import { constructDatePartsFromDate, getDaysInMonth } from './date'
 import type { DateFieldName, EditStudyInputs } from './schemas'
 
 export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditStudyInputs => ({
@@ -48,7 +48,7 @@ const mapStatusToMandatoryDateFields = (previousStatus: string | null, newStatus
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- status might not exist in object
   const mandatoryDates = mandatoryDateFieldsByStatus[newStatus] || []
 
-  // Exceptions - there are a small amount of scenarios that relies on the previous status
+  // Exceptions - there are a some scenarios that rely on the previous status
   if (
     (previousStatus === (FormStudyStatus.InSetup as string) && newStatus === (FormStudyStatus.Suspended as string)) ||
     (previousStatus === (FormStudyStatus.Suspended as string) &&
@@ -73,7 +73,7 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
   const requiredFuture = dateValidationRules[fieldName].restrictions.includes('requiredFuture')
 
   if (!value) {
-    // Status based validation
+    // Mandatory fields based on status
     if (mapStatusToMandatoryDateFields(previousStatus, currentStatus).includes(fieldName)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -85,8 +85,32 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
     return
   }
 
+  // Checks to see if all date parts exist
+  if (!value.day) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${label} must include a day`,
+      path: [`${fieldName}-day`],
+    })
+  } else if (!value.month) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${label} must include month`,
+      path: [`${fieldName}-month`],
+    })
+  } else if (!value.year) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${label} must include year`,
+      path: [`${fieldName}-year`],
+    })
+  }
+
   // Basic date validation
-  if (Number(value.day) < 1 || Number(value.day) > 31) {
+  else if (
+    Number(value.day) < 1 ||
+    Number(value.day) > (value.month ? getDaysInMonth(Number(value.month) - 1, Number(value.year)) : 31)
+  ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: `${label} requires a valid day`,
@@ -101,11 +125,11 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
   } else if (value.year.length !== 4) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `${label} requires a valid year`,
+      message: `${label} must include 4 numbers`,
       path: [`${fieldName}-year`],
     })
 
-    // Specific date validation
+    // Custom date validation
   } else if (
     (requiredPast &&
       !dayjs(`${value.year}-${value.month.padStart(2, '0')}-${value.day.padStart(2, '0')}`).isBefore(dayjs())) ||

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -48,7 +48,7 @@ const mapStatusToMandatoryDateFields = (previousStatus: string | null, newStatus
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- status might not exist in object
   const mandatoryDates = mandatoryDateFieldsByStatus[newStatus] || []
 
-  // Exceptions - there are a some scenarios that rely on the previous status
+  // Exceptions - there are some scenarios that rely on the previous status
   if (
     (previousStatus === (FormStudyStatus.InSetup as string) && newStatus === (FormStudyStatus.Suspended as string)) ||
     (previousStatus === (FormStudyStatus.Suspended as string) &&

--- a/apps/web/src/utils/schemas/study.schema.ts
+++ b/apps/web/src/utils/schemas/study.schema.ts
@@ -22,7 +22,7 @@ export const studySchema = z
     actualClosureDate: dateSchema.optional().nullable(),
     estimatedReopeningDate: dateSchema.optional().nullable(),
     recruitmentTarget: z
-      .number({ invalid_type_error: 'Enter a valid UK target' })
+      .string({ invalid_type_error: 'Enter a valid UK target' })
       .optional()
       .refine(
         (value) =>


### PR DESCRIPTION
This PR:
- updates the basic date validation
- updates type=number fields to type=text based on this GDS [blog](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) which explains the issues with type=number