### PR TITLE
SE-183: Fix target default value

### DIFF
--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -12,7 +12,7 @@ export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditSt
   studyId: study.id,
   status: study.studyStatus,
   originalStatus: study.studyStatus,
-  recruitmentTarget: study.sampleSize?.toString() ?? undefined,
+  recruitmentTarget: study.sampleSize?.toString() ?? '',
   cpmsId: study.cpmsId.toString(),
   plannedOpeningDate: constructDatePartsFromDate(study.plannedOpeningDate),
   plannedClosureDate: constructDatePartsFromDate(study.plannedClosureDate),


### PR DESCRIPTION
This PR sets the default value of uk recruitment target to an empty string rather than undefined which the schema throws an error for. 