### PR TITLE
Se-183: Send notes when editing study

### DIFF
--- a/apps/web/src/constants/forms.ts
+++ b/apps/web/src/constants/forms.ts
@@ -20,3 +20,5 @@ export const FORM_SUCCESS_MESSAGES = {
   2: 'Your study data changes have been received. These will now be reviewed and applied to the study record. Until then, previous study data values will be displayed.', // Proposed study updates
   3: 'Your study data changes have been accepted.', // Direct study updates
 } as Record<number, string>
+
+export const UPDATE_FROM_SE_TEXT = 'Update from Sponsor Engagement Tool'

--- a/apps/web/src/lib/cpms/studies.ts
+++ b/apps/web/src/lib/cpms/studies.ts
@@ -45,7 +45,7 @@ export type UpdateStudyInput = Pick<
   | 'PlannedClosureToRecruitmentDate'
   | 'ActualClosureToRecruitmentDate'
   | 'EstimatedReopeningDate'
->
+> & { notes?: string }
 
 export interface UpdateStudyFromCPMSResponse {
   study: Study | null

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -8,7 +8,7 @@ import { createRequest, createResponse } from 'node-mocks-http'
 
 import { prismaMock } from '@/__mocks__/prisma'
 import { userWithSponsorContactRole } from '@/__mocks__/session'
-import { StudyUpdateRoute } from '@/@types/studies'
+import { Status, StudyUpdateRoute } from '@/@types/studies'
 import { StudyUpdateType } from '@/constants'
 import type { EditStudyInputs } from '@/utils/schemas'
 
@@ -65,6 +65,7 @@ const body: EditStudyInputs = {
   studyId: mockStudyId,
   cpmsId: mockCPMSStudy.StudyId.toString(),
   status: mockCPMSStudy.StudyStatus,
+  originalStatus: Status.OpenToRecruitment,
   plannedOpeningDate: {
     day: '28',
     month: '02',

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -293,7 +293,7 @@ describe('/api/forms/editStudy', () => {
       expect(mockedPutAxios).toHaveBeenCalledTimes(1)
       expect(mockedPutAxios).toHaveBeenCalledWith(
         `${mockedEnvVars.apiUrl}/studies/${body.cpmsId}/engagement-info`,
-        JSON.stringify(mockCPMSUpdateInput),
+        JSON.stringify({ ...mockCPMSUpdateInput, notes: 'Update from Sponsor Engagement Tool' }),
         {
           headers: {
             'Content-Type': 'application/json',

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -78,12 +78,17 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
     })
 
     if (isDirectUpdate) {
-      // Only send additional note if new status is Suspended
-      const additionalNote = (
-        [Status.SuspendedFromOpenToRecruitment, Status.SuspendedFromOpenWithRecruitment, Status.Suspended] as string[]
-      ).includes(studyData.status)
-        ? UPDATE_FROM_SE_TEXT
-        : ''
+      // Only send additional note if new status is Suspended and not the original status
+      // i.e. a status has been changed to Suspended
+      const suspendedStatuses: string[] = [
+        Status.SuspendedFromOpenToRecruitment,
+        Status.SuspendedFromOpenWithRecruitment,
+        Status.Suspended,
+      ]
+      const additionalNote =
+        suspendedStatuses.includes(studyData.status) && !suspendedStatuses.includes(studyData.originalStatus ?? '')
+          ? UPDATE_FROM_SE_TEXT
+          : ''
 
       const { study, error: updateStudyError } = await updateStudyInCPMS(Number(studyData.cpmsId), {
         ...cpmsStudyInput,


### PR DESCRIPTION
This PR sends a `notes` attribute when editing a study - specifically when a status has changed to Suspended.