### PR TITLE
SE-167: Fix due assessment logic and warning text

### DIFF
--- a/apps/web/src/lib/studies.spec.ts
+++ b/apps/web/src/lib/studies.spec.ts
@@ -593,6 +593,7 @@ describe('mapCPMSStudyToSEStudy', () => {
     actualOpeningDate: new Date(mockCPMSStudy.ActualOpeningDate as string),
     actualClosureDate: new Date(mockCPMSStudy.ActualClosureToRecruitmentDate as string),
     estimatedReopeningDate: new Date(mockCPMSStudy.EstimatedReopeningDate as string),
+    isDueAssessment: false,
   }
 
   it('correctly maps data when all fields exist', () => {

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -447,7 +447,9 @@ export const updateEvaluationCategories = async (
 
 export const setStudyAssessmentDueFlag = async (studyIds: number[]) => {
   try {
-    await setStudyAssessmentDue(studyIds)
+    const assessmentDueResult = await setStudyAssessmentDue(studyIds)
+
+    return { data: assessmentDueResult.count }
   } catch (error) {
     const errorMessage = getErrorMessage(error)
 

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -339,6 +339,7 @@ export const mapCPMSStudyToSEStudy = (study: Study): UpdateStudyInput => ({
   actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
   actualClosureDate: study.ActualClosureToRecruitmentDate ? new Date(study.ActualClosureToRecruitmentDate) : null,
   estimatedReopeningDate: study.EstimatedReopeningDate ? new Date(study.EstimatedReopeningDate) : null,
+  isDueAssessment: false,
 })
 
 export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) => {

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -421,8 +421,6 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
 
   const { data: updatedStudy } = await updateStudy(Number(cpmsId), mapCPMSStudyToSEStudy(studyInCPMS))
 
-  await setStudyAssessmentDueFlag([study.id])
-
   if (!updatedStudy) {
     return {
       props: {
@@ -431,6 +429,9 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
       },
     }
   }
+
+  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueFlag([study.id])
+  const isStudyDueAssessment = setStudyAssessmentDueResponse !== null ? setStudyAssessmentDueResponse === 1 : false
 
   const currentStudyEvalsInSE = updatedStudy.evaluationCategories
 
@@ -451,7 +452,11 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
   return {
     props: {
       user: session.user,
-      study: { ...updatedStudy, evaluationCategories: updatedStudyEvals ?? study.evaluationCategories },
+      study: {
+        ...updatedStudy,
+        evaluationCategories: updatedStudyEvals ?? study.evaluationCategories,
+        isDueAssessment: isStudyDueAssessment,
+      },
     },
   }
 })

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -331,7 +331,7 @@ export default function EditStudy({ study }: EditStudyProps) {
 
               {showLoadingState ? (
                 <Warning>
-                  It may a few seconds for the CPMS record to update. Please stay on this page until redirected.
+                  It may take a few seconds for the record to update. Please stay on this page until redirected.
                 </Warning>
               ) : null}
 

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -258,7 +258,8 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     }
   }
 
-  await setStudyAssessmentDueFlag([studyId])
+  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueFlag([studyId])
+  const isStudyDueAssessment = setStudyAssessmentDueResponse !== null ? setStudyAssessmentDueResponse === 1 : false
 
   const currentStudyEvalsInSE = updatedStudy.evaluationCategories
 
@@ -280,7 +281,11 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     props: {
       user: session.user,
       assessments: getAssessmentHistoryFromStudy(study),
-      study: { ...updatedStudy, evaluationCategories: updatedStudyEvals ?? study.evaluationCategories },
+      study: {
+        ...updatedStudy,
+        evaluationCategories: updatedStudyEvals ?? study.evaluationCategories,
+        isDueAssessment: isStudyDueAssessment,
+      },
     },
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "sponsor-engagement-web",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -7730,9 +7729,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -20126,7 +20125,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@nihr-ui/logger": "*",
-        "@prisma/client": "latest"
+        "@prisma/client": "latest",
+        "dayjs": "^1.11.13"
       },
       "devDependencies": {
         "@types/jest": "^29.5.13",

--- a/packages/shared-utilities/package.json
+++ b/packages/shared-utilities/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@nihr-ui/logger": "*",
-    "@prisma/client": "latest"
+    "@prisma/client": "latest",
+    "dayjs": "^1.11.13"
   },
   "devDependencies": {
     "@types/jest": "^29.5.13",

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
@@ -1,9 +1,9 @@
+import assert from 'node:assert'
 import { logger } from '@nihr-ui/logger'
 import dayjs from 'dayjs'
 import { prismaClient } from '../../utils/prisma'
-import assert from 'assert'
 
-export const setStudyAssessmentDue = async (studyIds: number[]): Promise<void> => {
+export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count: number }> => {
   const { ASSESSMENT_LAPSE_MONTHS } = process.env
 
   assert(ASSESSMENT_LAPSE_MONTHS)
@@ -31,4 +31,6 @@ export const setStudyAssessmentDue = async (studyIds: number[]): Promise<void> =
   })
 
   logger.info(`Flagged ${assessmentDueResult.count} studies as being due assessment`)
+
+  return { count: assessmentDueResult.count }
 }

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'assert'
 import { logger } from '@nihr-ui/logger'
 import dayjs from 'dayjs'
 import { prismaClient } from '../../utils/prisma'

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
@@ -1,5 +1,5 @@
-import { setStudyAssessmentDue } from './index'
 import { prismaMock } from '../../mocks/prisma'
+import { setStudyAssessmentDue } from './index'
 
 jest.mock('@nihr-ui/logger')
 
@@ -7,10 +7,11 @@ const mockStudyIds = [12, 32, 23]
 
 describe('setStudyAssessmentDue()', () => {
   it('should update the study `isDueAssessment` flag', async () => {
-    prismaMock.study.updateMany.mockResolvedValueOnce({ count: 1 })
+    prismaMock.study.updateMany.mockResolvedValueOnce({ count: mockStudyIds.length })
 
-    await setStudyAssessmentDue(mockStudyIds)
+    const response = await setStudyAssessmentDue(mockStudyIds)
 
+    expect(response).toEqual({ count: mockStudyIds.length })
     expect(prismaMock.study.updateMany).toHaveBeenCalledTimes(1)
 
     expect(prismaMock.study.updateMany).toHaveBeenCalledWith({


### PR DESCRIPTION
This PR:
- fixes warning text when saving a study
- sets isDueAssessment flag when we pull data from CPMS and save to SE

There is a separate function which sets the is due flag to true if required. 