### PR TITLE
SE-168: Update StudyUpdates schema and edit logic

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "react-use-pagination": "^2.0.1",
     "shared-utilities": "*",
     "superjson": "^1.13.3",
+    "uuid": "^10.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -65,6 +66,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.1",
     "@types/testing-library__jest-dom": "^5.14.6",
+    "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.16",
     "cf-content-types-generator": "^2.15.3",
     "jest": "^29.7.0",

--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -26,6 +26,7 @@ const mockSetStudyAssessmentDue = setStudyAssessmentDue as jest.MockedFunction<t
 
 const mockStudyId = mockStudyWithRelations.id.toString()
 
+const mockLSN = '1212'
 const mockCPMSResponse = {
   StatusCode: 200,
   Result: mockCPMSStudy,
@@ -169,6 +170,7 @@ describe('EditStudy', () => {
             evaluationCategories: mappedCPMSStudyEvals,
             organisationsByRole,
           },
+          LSN: mockLSN,
         },
       })
 
@@ -240,6 +242,7 @@ describe('EditStudy', () => {
             ...mockStudyWithRelations,
             organisationsByRole,
           },
+          LSN: mockLSN,
         },
       })
 
@@ -268,6 +271,7 @@ describe('EditStudy', () => {
             evaluationCategories: mappedCPMSStudyEvals,
             organisationsByRole,
           },
+          LSN: mockLSN,
         },
       })
 
@@ -298,6 +302,7 @@ describe('EditStudy', () => {
             organisationsByRole,
             isDueAssessment: true,
           },
+          LSN: mockLSN,
         },
       })
 

--- a/apps/web/src/constants/editStudyForm.ts
+++ b/apps/web/src/constants/editStudyForm.ts
@@ -61,7 +61,7 @@ export const FURTHER_INFO_MAX_CHARACTERS = 500
 export const UK_RECRUITMENT_TARGET_MAX_VALUE = 9999999
 
 export const fieldNameToLabelMapping: Record<
-  keyof Omit<EditStudyInputs, 'studyId' | 'cpmsId' | 'originalStatus'>,
+  keyof Omit<EditStudyInputs, 'studyId' | 'cpmsId' | 'originalStatus' | 'LSN'>,
   string
 > = {
   plannedOpeningDate: 'Planned opening to recruitment date',

--- a/apps/web/src/constants/identifiers.ts
+++ b/apps/web/src/constants/identifiers.ts
@@ -12,3 +12,12 @@ export enum StudyUpdateType {
   Direct = 1,
   Proposed = 2,
 }
+
+/**
+ * The state of a study update - Before/After
+ * This should match the values in SysRefStudyUpdateState table
+ */
+export enum StudyUpdateState {
+  Before = 1,
+  After = 2,
+}

--- a/apps/web/src/lib/studyUpdates.ts
+++ b/apps/web/src/lib/studyUpdates.ts
@@ -1,0 +1,67 @@
+import type { Prisma } from 'database'
+import { v4 as uuid } from 'uuid'
+
+import { StudyUpdateState, StudyUpdateType } from '@/constants'
+import { constructDateObjFromParts } from '@/utils/date'
+import type { EditStudy, EditStudyInputs } from '@/utils/schemas'
+
+import { prismaClient } from './prisma'
+import { mapCPMSStatusToFormStatus } from './studies'
+
+export const logStudyUpdate = async (
+  studyId: number,
+  originalStudyValues: EditStudy['originalValues'],
+  newStudyValues: EditStudyInputs,
+  isDirectUpdate: boolean,
+  userId: number,
+  beforeLSN?: string,
+  afterLSN?: string
+) => {
+  const transactionId = uuid()
+
+  const studyUpdateBefore: Prisma.StudyUpdatesCreateManyInput = {
+    studyId,
+    studyStatus: originalStudyValues.status,
+    studyStatusGroup: mapCPMSStatusToFormStatus(originalStudyValues.status),
+    plannedOpeningDate: constructDateObjFromParts(originalStudyValues.plannedOpeningDate),
+    actualOpeningDate: constructDateObjFromParts(originalStudyValues.actualOpeningDate),
+    plannedClosureToRecruitmentDate: constructDateObjFromParts(originalStudyValues.plannedClosureDate),
+    actualClosureToRecruitmentDate: constructDateObjFromParts(originalStudyValues.actualClosureDate),
+    estimatedReopeningDate: constructDateObjFromParts(originalStudyValues.estimatedReopeningDate),
+    ukRecruitmentTarget: originalStudyValues.recruitmentTarget
+      ? Number(originalStudyValues.recruitmentTarget)
+      : undefined,
+    comment: originalStudyValues.furtherInformation,
+    transactionId,
+    LSN: beforeLSN ? Buffer.from(beforeLSN) : null,
+    studyUpdateStateId: StudyUpdateState.Before,
+    studyUpdateTypeId: isDirectUpdate ? StudyUpdateType.Direct : StudyUpdateType.Proposed,
+    createdById: userId,
+    modifiedById: userId,
+  }
+
+  const studyUpdateAfter: Prisma.StudyUpdatesCreateManyInput = {
+    studyId,
+    // For proposed changes, we do not know which CPMS status to map to based on the status the user sees
+    // Therefore, this is only saved if it is a direct update. But studyStatusGroup is always set.
+    studyStatus: isDirectUpdate ? newStudyValues.status : null,
+    studyStatusGroup: mapCPMSStatusToFormStatus(newStudyValues.status),
+    plannedOpeningDate: constructDateObjFromParts(newStudyValues.plannedOpeningDate),
+    actualOpeningDate: constructDateObjFromParts(newStudyValues.actualOpeningDate),
+    plannedClosureToRecruitmentDate: constructDateObjFromParts(newStudyValues.plannedClosureDate),
+    actualClosureToRecruitmentDate: constructDateObjFromParts(newStudyValues.actualClosureDate),
+    estimatedReopeningDate: constructDateObjFromParts(newStudyValues.estimatedReopeningDate),
+    ukRecruitmentTarget: newStudyValues.recruitmentTarget ? Number(newStudyValues.recruitmentTarget) : undefined,
+    comment: newStudyValues.furtherInformation,
+    transactionId,
+    LSN: afterLSN ? Buffer.from(afterLSN) : null,
+    studyUpdateStateId: StudyUpdateState.After,
+    studyUpdateTypeId: isDirectUpdate ? StudyUpdateType.Direct : StudyUpdateType.Proposed,
+    createdById: userId,
+    modifiedById: userId,
+  }
+
+  await prismaClient.studyUpdates.createMany({
+    data: [studyUpdateBefore, studyUpdateAfter],
+  })
+}

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -1,20 +1,16 @@
-import type { Prisma } from 'database'
 import type { NextApiRequest } from 'next'
-import { v4 as uuid } from 'uuid'
 
 import { Status, StudyUpdateRoute } from '@/@types/studies'
-import { Roles, StudyUpdateState, StudyUpdateType } from '@/constants'
+import { Roles } from '@/constants'
 import { UPDATE_FROM_SE_TEXT } from '@/constants/forms'
 import { mapEditStudyInputToCPMSStudy, updateStudyInCPMS, validateStudyUpdate } from '@/lib/cpms/studies'
-import { prismaClient } from '@/lib/prisma'
-import { mapCPMSStatusToFormStatus } from '@/lib/studies'
-import { constructDateObjFromParts } from '@/utils/date'
-import type { EditStudyInputs } from '@/utils/schemas'
+import { logStudyUpdate } from '@/lib/studyUpdates'
+import type { EditStudy } from '@/utils/schemas'
 import { studySchema } from '@/utils/schemas'
 import { withApiHandler } from '@/utils/withApiHandler'
 
 export interface ExtendedNextApiRequest extends NextApiRequest {
-  body: EditStudyInputs
+  body: EditStudy
 }
 
 export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, async (req, res, session) => {
@@ -23,11 +19,13 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
   const enableDirectStudyUpdatesFeature = ENABLE_DIRECT_STUDY_UPDATES?.toLowerCase() === 'true'
 
   try {
-    const studyData = studySchema.parse(req.body)
-    const cpmsStudyInput = mapEditStudyInputToCPMSStudy(studyData)
+    const { studyId, originalValues, LSN: beforeLSN } = req.body
+
+    const studyDataToUpdate = studySchema.parse(req.body)
+    const cpmsStudyInput = mapEditStudyInputToCPMSStudy(studyDataToUpdate)
 
     const { validationResult, error: validateStudyError } = await validateStudyUpdate(
-      Number(studyData.cpmsId),
+      Number(studyDataToUpdate.cpmsId),
       cpmsStudyInput
     )
 
@@ -41,37 +39,6 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
       ? validationResult.StudyUpdateRoute === StudyUpdateRoute.Direct
       : false
 
-    const formattedPlannedOpeningDate = constructDateObjFromParts(studyData.plannedOpeningDate)
-    const formattedActualOpeningDate = constructDateObjFromParts(studyData.actualOpeningDate)
-    const formattedPlannedClosureDate = constructDateObjFromParts(studyData.plannedClosureDate)
-    const formattedActualClosureDate = constructDateObjFromParts(studyData.actualClosureDate)
-    const formattedEstimatedReopeningDate = constructDateObjFromParts(studyData.estimatedReopeningDate)
-
-    const transactionId = uuid()
-
-    const studyUpdateAfter: Prisma.StudyUpdatesCreateManyInput = {
-      studyId: studyData.studyId,
-      studyStatus: isDirectUpdate ? studyData.status : null,
-      studyStatusGroup: mapCPMSStatusToFormStatus(studyData.status),
-      plannedOpeningDate: formattedPlannedOpeningDate,
-      actualOpeningDate: formattedActualOpeningDate,
-      plannedClosureToRecruitmentDate: formattedPlannedClosureDate,
-      actualClosureToRecruitmentDate: formattedActualClosureDate,
-      estimatedReopeningDate: formattedEstimatedReopeningDate,
-      ukRecruitmentTarget: studyData.recruitmentTarget ? Number(studyData.recruitmentTarget) : undefined,
-      comment: studyData.furtherInformation,
-      transactionId,
-      studyUpdateStateId: StudyUpdateState.After,
-      studyUpdateTypeId: isDirectUpdate ? StudyUpdateType.Direct : StudyUpdateType.Proposed,
-      createdById: session.user.id,
-      modifiedById: session.user.id,
-    }
-
-    // Both proposed and direct changes are saved to SE
-    await prismaClient.studyUpdates.createMany({
-      data: [studyUpdateAfter],
-    })
-
     if (isDirectUpdate) {
       // Only send additional note if new status is Suspended and not the original status
       // i.e. a status has been changed to Suspended
@@ -81,11 +48,11 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
         Status.Suspended,
       ]
       const additionalNote =
-        suspendedStatuses.includes(studyData.status) && !suspendedStatuses.includes(studyData.originalStatus ?? '')
+        suspendedStatuses.includes(studyDataToUpdate.status) && !suspendedStatuses.includes(originalValues.status)
           ? UPDATE_FROM_SE_TEXT
           : ''
 
-      const { study, error: updateStudyError } = await updateStudyInCPMS(Number(studyData.cpmsId), {
+      const { study, error: updateStudyError } = await updateStudyInCPMS(Number(studyDataToUpdate.cpmsId), {
         ...cpmsStudyInput,
         notes: additionalNote,
       })
@@ -95,7 +62,10 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
       }
     }
 
-    return res.redirect(302, `/studies/${studyData.studyId}?success=${isDirectUpdate ? 3 : 2}`)
+    // TODO: Update afterLSN once available from PUT request
+    await logStudyUpdate(studyId, originalValues, studyDataToUpdate, isDirectUpdate, session.user.id, beforeLSN, '')
+
+    return res.redirect(302, `/studies/${studyId}?success=${isDirectUpdate ? 3 : 2}`)
   } catch (e) {
     const searchParams = new URLSearchParams({ fatal: '1' })
     const studyId = req.body.studyId

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/lib/studies'
 import { areAllDatePartsEmpty } from '@/utils/date'
 import { getVisibleFormFields, mapStudyToStudyFormInput } from '@/utils/editStudyForm'
-import type { EditStudyInputs } from '@/utils/schemas'
+import type { EditStudy as EditStudySchema, EditStudyInputs } from '@/utils/schemas'
 import { studySchema } from '@/utils/schemas'
 import { withServerSideProps } from '@/utils/withServerSideProps'
 
@@ -50,11 +50,15 @@ const transformDateValue = (input?: DateInputValue | null) => ({
   year: input?.year ?? '',
 })
 
-export default function EditStudy({ study }: EditStudyProps) {
-  const { register, formState, handleSubmit, control, watch, setError } = useForm<EditStudyInputs>({
+export default function EditStudy({ study, LSN }: EditStudyProps) {
+  const mappedFormInput = mapStudyToStudyFormInput(study)
+
+  const { register, formState, handleSubmit, control, watch, setError } = useForm<EditStudySchema>({
     resolver: zodResolver(studySchema),
     defaultValues: {
-      ...mapStudyToStudyFormInput(study),
+      ...mappedFormInput,
+      originalValues: mappedFormInput,
+      LSN,
     },
     mode: 'onSubmit',
     reValidateMode: 'onSubmit',
@@ -457,6 +461,7 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
         evaluationCategories: updatedStudyEvals ?? study.evaluationCategories,
         isDueAssessment: isStudyDueAssessment,
       },
+      LSN: '1212', // TODO: Update from GET response
     },
   }
 })

--- a/apps/web/src/utils/editStudyForm.ts
+++ b/apps/web/src/utils/editStudyForm.ts
@@ -6,12 +6,12 @@ import { mapCPMSStatusToFormStatus } from '@/lib/studies'
 import type { EditStudyProps } from '@/pages/studies/[studyId]/edit'
 
 import { constructDatePartsFromDate, getDaysInMonth } from './date'
-import type { DateFieldName, EditStudyInputs } from './schemas'
+import type { DateFieldName, EditStudy, EditStudyInputs } from './schemas'
 
-export const mapStudyToStudyFormInput = (study: EditStudyProps['study']): EditStudyInputs => ({
+export const mapStudyToStudyFormInput = (study: EditStudyProps['study'], LSN?: string): EditStudyInputs => ({
   studyId: study.id,
+  LSN,
   status: study.studyStatus,
-  originalStatus: study.studyStatus,
   recruitmentTarget: study.sampleSize?.toString() ?? '',
   cpmsId: study.cpmsId.toString(),
   plannedOpeningDate: constructDatePartsFromDate(study.plannedOpeningDate),
@@ -118,10 +118,10 @@ export const getVisibleFormFields = (
 /**
  * Validates a date on the edit study form and sends errors to zod ctx
  */
-const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, values: EditStudyInputs) => {
+const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, values: EditStudy) => {
   const value = values[fieldName]
   const currentStatus = mapCPMSStatusToFormStatus(values.status)
-  const previousStatus = values.originalStatus ? mapCPMSStatusToFormStatus(values.originalStatus) : null
+  const previousStatus = values.originalValues.status ? mapCPMSStatusToFormStatus(values.originalValues.status) : null
   const label = fieldNameToLabelMapping[fieldName]
   const requiredPastOrCurrent = dateValidationRules[fieldName].restrictions.includes('requiredPastOrCurrent')
   const requiredFuture = dateValidationRules[fieldName].restrictions.includes('requiredFuture')
@@ -246,7 +246,7 @@ const validateDate = (fieldName: keyof DateFieldName, ctx: z.RefinementCtx, valu
 /**
  * Validates all dates on the edit study form and sends errors to zod ctx
  */
-export const validateAllDates = (ctx: z.RefinementCtx, values: EditStudyInputs) => {
+export const validateAllDates = (ctx: z.RefinementCtx, values: EditStudy) => {
   Object.keys(dateValidationRules).forEach((fieldName: keyof DateFieldName) => {
     validateDate(fieldName, ctx, values)
   })

--- a/apps/web/src/utils/schemas/study.schema.ts
+++ b/apps/web/src/utils/schemas/study.schema.ts
@@ -4,23 +4,26 @@ import { UK_RECRUITMENT_TARGET_MAX_VALUE } from '@/constants/editStudyForm'
 
 import { validateAllDates } from '../editStudyForm'
 
-const dateSchema = z.object({
-  year: z.string(),
-  day: z.string(),
-  month: z.string(),
-})
+const dateSchema = z
+  .object({
+    year: z.string(),
+    day: z.string(),
+    month: z.string(),
+  })
+  .optional()
+  .nullable()
 
 export const studySchema = z
   .object({
     studyId: z.number(),
     cpmsId: z.string(),
-    originalStatus: z.string().optional().nullable(),
     status: z.string(),
-    plannedOpeningDate: dateSchema.optional().nullable(),
-    actualOpeningDate: dateSchema.optional().nullable(),
-    plannedClosureDate: dateSchema.optional().nullable(),
-    actualClosureDate: dateSchema.optional().nullable(),
-    estimatedReopeningDate: dateSchema.optional().nullable(),
+    LSN: z.string().optional(),
+    plannedOpeningDate: dateSchema,
+    actualOpeningDate: dateSchema,
+    plannedClosureDate: dateSchema,
+    actualClosureDate: dateSchema,
+    estimatedReopeningDate: dateSchema,
     recruitmentTarget: z
       .string({ invalid_type_error: 'Enter a valid UK target' })
       .optional()
@@ -30,12 +33,24 @@ export const studySchema = z
         'Enter a valid UK target'
       ),
     furtherInformation: z.string().optional(),
+    originalValues: z.object({
+      status: z.string(),
+      plannedOpeningDate: dateSchema,
+      actualOpeningDate: dateSchema,
+      plannedClosureDate: dateSchema,
+      actualClosureDate: dateSchema,
+      estimatedReopeningDate: dateSchema,
+      recruitmentTarget: z.string().optional(),
+      furtherInformation: z.string().optional(),
+    }),
   })
   .superRefine((values, ctx) => {
     validateAllDates(ctx, values)
   })
 
-export type EditStudyInputs = z.infer<typeof studySchema>
+export type EditStudy = z.infer<typeof studySchema>
+
+export type EditStudyInputs = Omit<EditStudy, 'originalValues'>
 
 export type DateFieldName = Pick<
   EditStudyInputs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,7 @@
         "react-use-pagination": "^2.0.1",
         "shared-utilities": "*",
         "superjson": "^1.13.3",
+        "uuid": "^10.0.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -192,6 +193,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/testing-library__jest-dom": "^5.14.6",
+        "@types/uuid": "^10.0.0",
         "autoprefixer": "^10.4.16",
         "cf-content-types-generator": "^2.15.3",
         "jest": "^29.7.0",
@@ -212,6 +214,18 @@
     "apps/web/node_modules/@types/node": {
       "version": "20.2.5",
       "license": "MIT"
+    },
+    "apps/web/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -4772,6 +4786,12 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",

--- a/packages/database/prisma/migrations/20241011092956_study_updates_state_transaction/migration.sql
+++ b/packages/database/prisma/migrations/20241011092956_study_updates_state_transaction/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - Added the required column `studyUpdateStateId` to the `StudyUpdates` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `transactionId` to the `StudyUpdates` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DeleteRows
+TRUNCATE `StudyUpdates`;
+
+-- AlterTable
+ALTER TABLE `StudyUpdates` ADD COLUMN `studyUpdateStateId` INTEGER NOT NULL,
+    ADD COLUMN `transactionId` VARCHAR(191) NOT NULL;
+
+-- CreateTable
+CREATE TABLE `SysRefStudyUpdateState` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `state` VARCHAR(191) NOT NULL,
+    `description` TEXT NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `StudyUpdates` ADD CONSTRAINT `StudyUpdates_studyUpdateStateId_fkey` FOREIGN KEY (`studyUpdateStateId`) REFERENCES `SysRefStudyUpdateState`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Seed data
+INSERT INTO `SysRefStudyUpdateState` (`id`, `state`, `description`) VALUES
+  (1, 'Before', 'The state of a study before the update is applied'),
+  (2, 'After', 'The state of a study after the update is applied');

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -210,8 +210,8 @@ model AssessmentReminder {
 }
 
 model StudyUpdates {
-  id                              Int                   @id @default(autoincrement())
-  study                           Study                 @relation(fields: [studyId], references: [id])
+  id                              Int                    @id @default(autoincrement())
+  study                           Study                  @relation(fields: [studyId], references: [id])
   studyId                         Int
   studyStatus                     String?
   studyStatusGroup                String
@@ -221,17 +221,27 @@ model StudyUpdates {
   actualClosureToRecruitmentDate  DateTime?
   estimatedReopeningDate          DateTime?
   ukRecruitmentTarget             Int?
-  studyUpdateType                 SysRefStudyUpdateType @relation(fields: [studyUpdateTypeId], references: [id])
+  studyUpdateType                 SysRefStudyUpdateType  @relation(fields: [studyUpdateTypeId], references: [id])
   studyUpdateTypeId               Int
-  comment                         String?               @db.VarChar(500)
-  isDeleted                       Boolean?              @default(false) @db.TinyInt()
-  LSN                             Bytes?                @db.Binary(10)
-  createdAt                       DateTime              @default(now())
-  createdBy                       User                  @relation("createdStudyUpdates", fields: [createdById], references: [id])
+  comment                         String?                @db.VarChar(500)
+  isDeleted                       Boolean?               @default(false) @db.TinyInt()
+  LSN                             Bytes?                 @db.Binary(10)
+  transactionId                   String
+  studyUpdateState                SysRefStudyUpdateState @relation(fields: [studyUpdateStateId], references: [id])
+  studyUpdateStateId              Int
+  createdAt                       DateTime               @default(now())
+  createdBy                       User                   @relation("createdStudyUpdates", fields: [createdById], references: [id])
   createdById                     Int
-  modifiedAt                      DateTime              @updatedAt
-  modifiedBy                      User                  @relation("modifiedStudyUpdates", fields: [modifiedById], references: [id])
+  modifiedAt                      DateTime               @updatedAt
+  modifiedBy                      User                   @relation("modifiedStudyUpdates", fields: [modifiedById], references: [id])
   modifiedById                    Int
+}
+
+model SysRefStudyUpdateState {
+  id           Int            @id @default(autoincrement())
+  state        String
+  description  String         @db.Text
+  StudyUpdates StudyUpdates[]
 }
 
 model SysRefStudyUpdateType {


### PR DESCRIPTION
This PR:
- updates the StudyUpdates to include two new fields `transactionId` and `studyUpdateState`
- ensures that two entries are logged in the table (one for before and after)


Follow up PR needs to pass through the correct LSN values