### PR TITLE
SE-121: Check user organisation on edit page

### DIFF
--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -389,7 +389,9 @@ export const getServerSideProps = withServerSideProps(Roles.SponsorContact, asyn
     }
   }
 
-  const { data: study } = await getStudyById(Number(context.query.studyId))
+  const userOrganisationIds = session.user?.organisations.map((userOrg) => userOrg.organisationId)
+
+  const { data: study } = await getStudyById(Number(context.query.studyId), userOrganisationIds)
 
   if (!study) {
     return {


### PR DESCRIPTION
This PR passes in user organisation ids when fetching study to ensure users can only access studies that are part of their organisation. 