### PR TITLE
SE-199

### DIFF
--- a/apps/web/src/components/molecules/EditHistory/utils.spec.ts
+++ b/apps/web/src/components/molecules/EditHistory/utils.spec.ts
@@ -28,6 +28,10 @@ describe('transformValue()', () => {
     const inputValue = 'unknownValue'
     expect(transformValue(inputValue)).toBe(inputValue)
   })
+
+  it('should return the mapped value if mapping exists', () => {
+    expect(transformValue('Closed to Recruitment')).toBe('Closed')
+  })
 })
 
 describe('createChangeHistoryForProposedChanges()', () => {

--- a/apps/web/src/components/molecules/EditHistory/utils.ts
+++ b/apps/web/src/components/molecules/EditHistory/utils.ts
@@ -4,6 +4,7 @@ import type { ChangeHistory } from '@/@types/studies'
 import { StudyUpdateState, StudyUpdateType } from '@/constants'
 import type { Prisma } from '@/lib/prisma'
 import { prismaClient } from '@/lib/prisma'
+import { mapCPMSStatusToFormStatus } from '@/lib/studies'
 import { formatDate } from '@/utils/date'
 import { getErrorMessage } from '@/utils/error'
 
@@ -34,7 +35,7 @@ export const transformValue = (value: string | null) => {
     return formatDate(value)
   }
 
-  return value
+  return mapCPMSStatusToFormStatus(value)
 }
 
 /**

--- a/apps/web/src/pages/api/export.spec.ts
+++ b/apps/web/src/pages/api/export.spec.ts
@@ -92,8 +92,6 @@ describe('Exporting studies list', () => {
       'Actual closure to recruitment date',
       'UK recruitment target',
       'Total UK recruitment to date',
-      'Network recruitment target',
-      'Total network recruitment to date',
       'Managing speciality',
       'Sponsor Assessment (On track or Off track)',
       'Additional Information (including any updates to study status, target, and/or date milestones)',
@@ -131,8 +129,6 @@ describe('Exporting studies list', () => {
       study.actualOpeningDate,
       study.plannedClosureDate,
       study.actualClosureDate,
-      undefined, // UK recruitment target
-      undefined, // Total UK recruitment to date
       study.sampleSize,
       study.totalRecruitmentToDate,
     ])
@@ -261,8 +257,8 @@ describe('Exporting studies list', () => {
       'Actual opening to recruitment date',
       'Planned closure to recruitment date',
       'Actual closure to recruitment date',
-      'Network recruitment target',
-      'Total network recruitment to date',
+      'UK recruitment target',
+      'Total UK recruitment to date',
       'Managing speciality',
       'Sponsor Assessment (On track or Off track)',
       'Additional Information (including any updates to study status, target, and/or date milestones)',

--- a/apps/web/src/pages/api/export.ts
+++ b/apps/web/src/pages/api/export.ts
@@ -29,8 +29,6 @@ const columns = [
   { key: 'actualClosureDate', header: 'Actual closure to recruitment date' },
   { key: 'recruitmentTargetUK', header: 'UK recruitment target' },
   { key: 'recruitmentToDateUK', header: 'Total UK recruitment to date' },
-  { key: 'recruitmentTargetNetwork', header: 'Network recruitment target' },
-  { key: 'recruitmentToDateNetwork', header: 'Total network recruitment to date' },
   { key: 'managingSpeciality', header: 'Managing speciality' },
   { key: 'onTrack', header: 'Sponsor Assessment (On track or Off track)' },
   {
@@ -42,19 +40,9 @@ const columns = [
 type Columns = typeof columns
 type ColumnKeys = Columns[number]['key']
 
-const commercialColumns: ColumnKeys[] = [
-  'studyCRO',
-  'protocolReferenceNumber',
-  'recruitmentTargetNetwork',
-  'recruitmentToDateNetwork',
-]
+const commercialColumns: ColumnKeys[] = ['studyCRO', 'protocolReferenceNumber']
 
-const nonCommercialColumns: ColumnKeys[] = [
-  'studyCTU',
-  'chiefInvestigator',
-  'recruitmentTargetUK',
-  'recruitmentToDateUK',
-]
+const nonCommercialColumns: ColumnKeys[] = ['studyCTU', 'chiefInvestigator']
 
 type StudyDataMapper = (study: StudyForExport) => string | number | Date | null | undefined
 
@@ -86,10 +74,8 @@ const studyDataMappers: Partial<Record<ColumnKeys, StudyDataMapper>> = {
   plannedClosureDate: (study) => study.plannedClosureDate,
   actualOpeningDate: (study) => study.actualOpeningDate,
   actualClosureDate: (study) => study.actualClosureDate,
-  recruitmentTargetUK: (study) => (study.route !== 'Commercial' ? study.sampleSize : undefined),
-  recruitmentToDateUK: (study) => (study.route !== 'Commercial' ? study.totalRecruitmentToDate : undefined),
-  recruitmentTargetNetwork: (study) => (study.route === 'Commercial' ? study.sampleSize : undefined),
-  recruitmentToDateNetwork: (study) => (study.route === 'Commercial' ? study.totalRecruitmentToDate : undefined),
+  recruitmentTargetUK: (study) => study.sampleSize,
+  recruitmentToDateUK: (study) => study.totalRecruitmentToDate,
   managingSpeciality: (study) => study.managingSpeciality,
 }
 


### PR DESCRIPTION
This PR:
- removes two fields from the export - 'Network recruitment target', 'Total network recruitment to date',
- ensures that 'UK recruitment target' and 'Total UK recruitment to date' always show the relevant value regardless if commercial or not. 