### PR TITLE
Send CurrentLsn to CPMS when editing study 

### DIFF
--- a/apps/web/src/components/molecules/EditHistory/EditHistoryChangeText/utils.ts
+++ b/apps/web/src/components/molecules/EditHistory/EditHistoryChangeText/utils.ts
@@ -2,8 +2,8 @@ import { fieldNameToLabelMapping } from '@/constants/editStudyForm'
 
 export const getColumnChangedLabelText = (key: string): string => {
   const mappings: Record<string, string> = {
+    // CPMS fields
     UkRecruitmentSampleSize: fieldNameToLabelMapping.recruitmentTarget,
-    ukRecruitmentTarget: fieldNameToLabelMapping.recruitmentTarget,
     StudyStatus: fieldNameToLabelMapping.status,
     PlannedOpeningDate: fieldNameToLabelMapping.plannedOpeningDate,
     ActualOpeningDate: fieldNameToLabelMapping.actualOpeningDate,
@@ -12,12 +12,16 @@ export const getColumnChangedLabelText = (key: string): string => {
     EstimatedReopeningDate: fieldNameToLabelMapping.estimatedReopeningDate,
     PlannedRecruitmentStartDate: fieldNameToLabelMapping.plannedOpeningDate,
     PlannedRecruitmentEndDate: fieldNameToLabelMapping.plannedClosureDate,
+    ActualClosureDate: fieldNameToLabelMapping.actualClosureDate,
+    PlannedClosureDate: fieldNameToLabelMapping.plannedClosureDate,
+    // SE fields
     studyStatusGroup: fieldNameToLabelMapping.status,
     actualClosureToRecruitmentDate: fieldNameToLabelMapping.actualClosureDate,
     plannedOpenngDate: fieldNameToLabelMapping.plannedOpeningDate,
     actualOpeningDate: fieldNameToLabelMapping.actualOpeningDate,
     plannedClosureToRecruitmentDate: fieldNameToLabelMapping.plannedClosureDate,
     estimatedReopeningDate: fieldNameToLabelMapping.estimatedReopeningDate,
+    ukRecruitmentTarget: fieldNameToLabelMapping.recruitmentTarget,
   }
 
   return mappings[key] || key

--- a/apps/web/src/lib/cpms/studies.ts
+++ b/apps/web/src/lib/cpms/studies.ts
@@ -51,7 +51,7 @@ export type UpdateStudyInput = Pick<
   | 'PlannedClosureToRecruitmentDate'
   | 'ActualClosureToRecruitmentDate'
   | 'EstimatedReopeningDate'
-> & { notes?: string }
+> & { notes?: string; CurrentLsn?: string | null }
 
 export interface UpdateStudyFromCPMSResponse {
   study: (Study & { UpdateLsn: string }) | null

--- a/apps/web/src/pages/api/forms/editStudy.spec.ts
+++ b/apps/web/src/pages/api/forms/editStudy.spec.ts
@@ -318,7 +318,7 @@ describe('/api/forms/editStudy', () => {
       expect(mockedPutAxios).toHaveBeenCalledTimes(1)
       expect(mockedPutAxios).toHaveBeenCalledWith(
         `${mockedEnvVars.apiUrl}/studies/${body.cpmsId}/engagement-info`,
-        JSON.stringify({ ...mockCPMSUpdateInput, notes: 'Update from Sponsor Engagement Tool' }),
+        JSON.stringify({ ...mockCPMSUpdateInput, CurrentLsn: '1212', notes: 'Update from Sponsor Engagement Tool' }),
         {
           headers: {
             'Content-Type': 'application/json',

--- a/apps/web/src/pages/api/forms/editStudy.ts
+++ b/apps/web/src/pages/api/forms/editStudy.ts
@@ -57,6 +57,7 @@ export default withApiHandler<ExtendedNextApiRequest>(Roles.SponsorContact, asyn
 
       const { study, error: updateStudyError } = await updateStudyInCPMS(Number(studyDataToUpdate.cpmsId), {
         ...cpmsStudyInput,
+        CurrentLsn: beforeLSN,
         notes: additionalNote,
       })
 


### PR DESCRIPTION
This PR sends the current lsn to the cpms endpoint when editing a study. 