### PR TITLE
SE-216: Fix page jumpiness on errors

### DIFF
--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -103,7 +103,7 @@ export default function EditStudy({ study, currentLSN }: EditStudyProps) {
   const showLoadingState = formState.isSubmitting || formState.isSubmitSuccessful
 
   useEffect(() => {
-    if (Object.values(errors).length > 0) {
+    if (Object.keys(errors).length > 0) {
       window.scrollTo({
         top: 0,
         behavior: 'smooth',

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import type { InferGetServerSidePropsType } from 'next'
 import Link from 'next/link'
 import { NextSeo } from 'next-seo'
-import { type ReactElement, useCallback, useMemo } from 'react'
+import { type ReactElement, useCallback, useEffect, useMemo } from 'react'
 import type { FieldError } from 'react-hook-form'
 import { Controller, useForm } from 'react-hook-form'
 
@@ -101,6 +101,15 @@ export default function EditStudy({ study, currentLSN }: EditStudyProps) {
   )
 
   const showLoadingState = formState.isSubmitting || formState.isSubmitSuccessful
+
+  useEffect(() => {
+    if (Object.values(errors).length > 0) {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      })
+    }
+  }, [errors])
 
   return (
     <Container>


### PR DESCRIPTION
This PR fixes a UX issue when the page jumps due to error messages appearing. 

To prevent the sight of this, we scroll to the top of the page. 