### PR TITLE
se phase 2 e2e wrap up pr v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,21 +271,28 @@ jobs:
       - name: Run All SE E2E Tests
         working-directory: ./packages/qa
         if: success()
-        run: npx playwright test --project=seDefault
+        run: npm test
         env:
           E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
-          SE_TEST_DB_PASSWORD: ${{ secrets.SE_TEST_DB_PASSWORD }}
+          SPONSOR_CONTACT_USER: ${{ secrets.SPONSOR_CONTACT_USER }}
+          SPONSOR_CONTACT_PASS: ${{ secrets.SPONSOR_CONTACT_PASS }}
+          SPONSOR_CONTACT_MANAGER_USER: ${{ secrets.SPONSOR_CONTACT_MANAGER_USER }}
+          SPONSOR_CONTACT_MANAGER_PASS: ${{ secrets.SPONSOR_CONTACT_MANAGER_PASS }}
+          CONTACT_MANAGER_USER: ${{ secrets.CONTACT_MANAGER_USER }}
+          CONTACT_MANAGER_PASS: ${{ secrets.CONTACT_MANAGER_PASS }}
+          SE_NO_LOCAL_ACCOUNT_USER: ${{ secrets.SE_NO_LOCAL_ACCOUNT_USER }}
+          SE_NO_LOCAL_ACCOUNT_PASS: ${{ secrets.SE_NO_LOCAL_ACCOUNT_PASS }}
+          CPMS_NPM_USER: ${{ secrets.CPMS_NPM_USER }}
+          CPMS_NPM_PASS: ${{ secrets.CPMS_NPM_PASS }}
           SE_TEST_DB_HOST: ${{ secrets.SE_TEST_DB_HOST }}
+          SE_TEST_DB_USERNAME: ${{ secrets.SE_TEST_DB_USERNAME }}
+          SE_TEST_DB_PASSWORD: ${{ secrets.SE_TEST_DB_PASSWORD }}
           SE_TEST_API_URL: ${{ secrets.CPMS_API_BASE_URL }}
           SE_TEST_API_USERNAME: ${{ secrets.CPMS_API_USERNAME }}
           SE_TEST_API_PASSWORD: ${{ secrets.CPMS_API_PASSWORD }}
-          SPONSOR_CONTACT_PASS: ${{ secrets.SPONSOR_CONTACT_PASS }}
-          SPONSOR_CONTACT_MANAGER_PASS: ${{ secrets.SPONSOR_CONTACT_MANAGER_PASS }}
-          CONTACT_MANAGER_PASS: ${{ secrets.CONTACT_MANAGER_PASS }}
-          SE_NO_LOCAL_ACCOUNT_PASS: ${{ secrets.SE_NO_LOCAL_ACCOUNT_PASS }}
-          CPMS_NPM_PASS: ${{ secrets.CPMS_NPM_PASS }}
-          CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
           CPMS_TEST_DB_IP: ${{ secrets.CPMS_TEST_DB_IP }}
+          CPMS_TEST_DB_USERNAME: ${{ secrets.CPMS_TEST_DB_USERNAME }}
+          CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
 
       - name: Remove Github Actions IP from CPMS API security group (Test)
         if: always()        

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -88,25 +88,32 @@ jobs:
       run: |
         if [[ "${{ github.event.inputs.test-tag }}" != '' && "${{ github.event.inputs.test-tag }}" != 'all' ]]; then
           echo "running only e2e tests tagged '${{ github.event.inputs.test-tag }}'"
-          npx playwright test npx playwright test --project=seDefault --grep ${{ github.event.inputs.test-tag }}
+          npm test -- --grep ${{ github.event.inputs.test-tag }}
         else
           echo "running all e2e tests"
-          npx playwright test npx playwright test --project=seDefault
+          npm test
         fi
       env:
         E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
-        SE_TEST_DB_PASSWORD: ${{ secrets.SE_TEST_DB_PASSWORD }}
+        SPONSOR_CONTACT_USER: ${{ secrets.SPONSOR_CONTACT_USER }}
+        SPONSOR_CONTACT_PASS: ${{ secrets.SPONSOR_CONTACT_PASS }}
+        SPONSOR_CONTACT_MANAGER_USER: ${{ secrets.SPONSOR_CONTACT_MANAGER_USER }}
+        SPONSOR_CONTACT_MANAGER_PASS: ${{ secrets.SPONSOR_CONTACT_MANAGER_PASS }}
+        CONTACT_MANAGER_USER: ${{ secrets.CONTACT_MANAGER_USER }}
+        CONTACT_MANAGER_PASS: ${{ secrets.CONTACT_MANAGER_PASS }}
+        SE_NO_LOCAL_ACCOUNT_USER: ${{ secrets.SE_NO_LOCAL_ACCOUNT_USER }}
+        SE_NO_LOCAL_ACCOUNT_PASS: ${{ secrets.SE_NO_LOCAL_ACCOUNT_PASS }}
+        CPMS_NPM_USER: ${{ secrets.CPMS_NPM_USER }}
+        CPMS_NPM_PASS: ${{ secrets.CPMS_NPM_PASS }}
         SE_TEST_DB_HOST: ${{ secrets.SE_TEST_DB_HOST }}
+        SE_TEST_DB_USERNAME: ${{ secrets.SE_TEST_DB_USERNAME }}
+        SE_TEST_DB_PASSWORD: ${{ secrets.SE_TEST_DB_PASSWORD }}
         SE_TEST_API_URL: ${{ secrets.CPMS_API_BASE_URL }}
         SE_TEST_API_USERNAME: ${{ secrets.CPMS_API_USERNAME }}
         SE_TEST_API_PASSWORD: ${{ secrets.CPMS_API_PASSWORD }}
-        SPONSOR_CONTACT_PASS: ${{ secrets.SPONSOR_CONTACT_PASS }}
-        SPONSOR_CONTACT_MANAGER_PASS: ${{ secrets.SPONSOR_CONTACT_MANAGER_PASS }}
-        CONTACT_MANAGER_PASS: ${{ secrets.CONTACT_MANAGER_PASS }}
-        SE_NO_LOCAL_ACCOUNT_PASS: ${{ secrets.SE_NO_LOCAL_ACCOUNT_PASS }}
-        CPMS_NPM_PASS: ${{ secrets.CPMS_NPM_PASS }}
-        CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
         CPMS_TEST_DB_IP: ${{ secrets.CPMS_TEST_DB_IP }}
+        CPMS_TEST_DB_USERNAME: ${{ secrets.CPMS_TEST_DB_USERNAME }}
+        CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
     
     - name: Remove Github Actions IP from CPMS API security group (Test)
       if: always()        

--- a/packages/qa/.env.example
+++ b/packages/qa/.env.example
@@ -1,21 +1,30 @@
 # env
-E2E_BASE_URL=
+E2E_BASE_URL=https://test.assessmystudy.nihr.ac.uk/
 
-# db
+# se db
 SE_TEST_DB_HOST=
+SE_TEST_DB_USERNAME=
 SE_TEST_DB_PASSWORD=
-CPMS_TEST_DB_PASSWORD=
-CPMS_TEST_DB_IP=
 
-# test users
+# cpms db
+CPMS_TEST_DB_IP=
+CPMS_TEST_DB_PASSWORD=
+CPMS_TEST_DB_USERNAME=
+
+# test user
+SPONSOR_CONTACT_USER=sesponsorcontact@test.id.nihr.ac.uk
 SPONSOR_CONTACT_PASS=
+SPONSOR_CONTACT_MANAGER_USER=sesponsorcontactmanager@test.id.nihr.ac.uk
 SPONSOR_CONTACT_MANAGER_PASS=
+CONTACT_MANAGER_USER=secontactmanager@test.id.nihr.ac.uk
 CONTACT_MANAGER_PASS=
+SE_NO_LOCAL_ACCOUNT_USER=senolocalaccount@test.id.nihr.ac.uk
 SE_NO_LOCAL_ACCOUNT_PASS=
+CPMS_NPM_USER=sim_auto_npm@test.id.nihr.ac.uk
 CPMS_NPM_PASS=
 
 # api
-SE_TEST_API_URL=
+SE_TEST_API_URL=https://test.cpmsapi.crncc.nihr.ac.uk/
 SE_TEST_API_USERNAME=
 SE_TEST_API_PASSWORD=
 

--- a/packages/qa/README.md
+++ b/packages/qa/README.md
@@ -28,24 +28,29 @@ Then populate the variables by retrieving from the following sources:
 
 ```text
   # env             # the SE environment you wish to test (currently only supports test)
-  E2E_BASE_URL=     # (currently only supports test)
+  E2E_BASE_URL=     #
+
+  # test users
+  SPONSOR_CONTACT_USER=sesponsorcontact@test.id.nihr.ac.uk
+  SPONSOR_CONTACT_PASS=
+  SPONSOR_CONTACT_MANAGER_USER=sesponsorcontactmanager@test.id.nihr.ac.uk
+  SPONSOR_CONTACT_MANAGER_PASS=
+  CONTACT_MANAGER_USER=secontactmanager@test.id.nihr.ac.uk
+  CONTACT_MANAGER_PASS=
+  SE_NO_LOCAL_ACCOUNT_USER=senolocalaccount@test.id.nihr.ac.uk
+  SE_NO_LOCAL_ACCOUNT_PASS=
+  CPMS_NPM_USER=sim_auto_npm@test.id.nihr.ac.uk
+  CPMS_NPM_PASS=
 
   # se db           # creds can be found in https://docs.google.com/document/d/1J9I1b4hb28rd9vl34Oe7XPCeZqk8yVsyG84KJgXS6k0
   SE_TEST_DB_HOST=
+  SE_TEST_DB_USERNAME
   SE_TEST_DB_PASSWORD=
 
   # cpms db         # creds ask nihr-managed-services
   CPMS_TEST_DB_PASSWORD=
+  CPMS_TEST_DB_USERNAME
   CPMS_TEST_DB_IP=
-
-  # se test users   # creds can be found in https://docs.google.com/document/d/1J9I1b4hb28rd9vl34Oe7XPCeZqk8yVsyG84KJgXS6k0
-  SPONSOR_CONTACT_PASS=
-  SPONSOR_CONTACT_MANAGER_PASS=
-  CONTACT_MANAGER_PASS=
-  SE_NO_LOCAL_ACCOUNT_PASS=
-
-  # cpms test users # creds can be found in https://docs.google.com/spreadsheets/d/1cNsHznOMg9DDkFJnrHUbgK2EoGFys9Hwy5c9n1rO0I4
-  CPMS_NPM_PASS=
 
   # api
   SE_TEST_API_URL=  # creds can be found in https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=crnccd-secret-test-se-app-config&region=eu-west-2

--- a/packages/qa/README.md
+++ b/packages/qa/README.md
@@ -1,6 +1,6 @@
 # Sponsor Engagement E2E Tests
 
-Written in Typescript, using Playwright with page object model & test steps.
+Written in Typescript with Playwright using page object model & test steps.
 
 Playwright [Documentation](https://playwright.dev/docs/intro)
 
@@ -28,9 +28,9 @@ Then populate the variables by retrieving from the following sources:
 
 ```text
   # env             # the SE environment you wish to test (currently only supports test)
-  E2E_BASE_URL=     #
+  E2E_BASE_URL=https://test.assessmystudy.nihr.ac.uk/
 
-  # test users
+  # test users      # creds can be found in https://docs.google.com/document/d/1J9I1b4hb28rd9vl34Oe7XPCeZqk8yVsyG84KJgXS6k0
   SPONSOR_CONTACT_USER=sesponsorcontact@test.id.nihr.ac.uk
   SPONSOR_CONTACT_PASS=
   SPONSOR_CONTACT_MANAGER_USER=sesponsorcontactmanager@test.id.nihr.ac.uk
@@ -85,7 +85,7 @@ If the above has been completed then simply run:
 
 - `npx playwright test --project=seDefault` - runs all tests and print results to the console.
 
-**Note:** alternatively you can run `npm run test`
+**Note:** alternatively you can run `npm test`
 
 ## Execute test locally (advanced)
 
@@ -95,9 +95,13 @@ To run tests using tags:
 
 - Run all tests with a given tag, then run:
   `npx playwright test --project=seDefault --grep <tag name>` - example: `npx playwright test --project=seDefault --grep @se_123_ac1`
+  or
+  `npm test -- --grep <tag name>`
 
 - Run all tests without a given tag, then run:
   `npx playwright test --project=seDefault --grep-invert <tag name>` - example: `npx playwright test --project=seDefault --grep-invert @wip`
+  or
+  `npm test -- --grep-invert <tag name>`
 
 **Note:** you can tag the individual `test()` or the `test.describe()`
 

--- a/packages/qa/package.json
+++ b/packages/qa/package.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "npx playwright test --project=seDefault",
-    "test:android": "npx playwright test --project=seMobileAndroid",
-    "test:axe": "(ENABLE_ACCESSIBILITY=true npx playwright test --project=seDefault --grep '@accessibility')",
-    "test:chrome": "npx playwright test --project=seChrome",
-    "test:edge": "npx playwright test --project=seEdge",
-    "test:firefox": "npx playwright test --project=seFirefox",
-    "test:iphone": "npx playwright test --project=seMobileIphone",
-    "test:safari": "npx playwright test --project=seSafari"
+    "test": "NODE_OPTIONS='--no-deprecation=DEP0123' playwright test --project=seDefault",
+    "test:android": "playwright test --project=seMobileAndroid",
+    "test:axe": "(ENABLE_ACCESSIBILITY=true playwright test --project=seDefault --grep '@accessibility')",
+    "test:chrome": "playwright test --project=seChrome",
+    "test:edge": "playwright test --project=seEdge",
+    "test:firefox": "playwright test --project=seFirefox",
+    "test:iphone": "playwright test --project=seMobileIphone",
+    "test:safari": "playwright test --project=seSafari"
   },
   "dependencies": {
     "@playwright/test": "^1.40.1",

--- a/packages/qa/pages/LoginPage.ts
+++ b/packages/qa/pages/LoginPage.ts
@@ -36,23 +36,23 @@ export default class LoginPage {
     let password = ''
     switch (user.toLowerCase()) {
       case 'sponsor contact':
-        username = 'sesponsorcontact@test.id.nihr.ac.uk'
+        username = `${process.env.SPONSOR_CONTACT_USER}`
         password = `${process.env.SPONSOR_CONTACT_PASS}`
         break
       case 'sponsor contact manager':
-        username = 'sesponsorcontactmanager@test.id.nihr.ac.uk'
+        username = `${process.env.SPONSOR_CONTACT_MANAGER_USER}`
         password = `${process.env.SPONSOR_CONTACT_MANAGER_PASS}`
         break
       case 'contact manager':
-        username = 'secontactmanager@test.id.nihr.ac.uk'
+        username = `${process.env.CONTACT_MANAGER_USER}`
         password = `${process.env.CONTACT_MANAGER_PASS}`
         break
       case 'no local account':
-        username = 'senolocalaccount@test.id.nihr.ac.uk'
+        username = `${process.env.SE_NO_LOCAL_ACCOUNT_USER}`
         password = `${process.env.SE_NO_LOCAL_ACCOUNT_PASS}`
         break
       case 'national portfolio manager':
-        username = 'sim_auto_npm@test.id.nihr.ac.uk'
+        username = `${process.env.CPMS_NPM_USER}`
         password = `${process.env.CPMS_NPM_PASS}`
         break
       default:

--- a/packages/qa/pages/StudyDetailsPage.ts
+++ b/packages/qa/pages/StudyDetailsPage.ts
@@ -90,6 +90,12 @@ export default class StudyDetailsPage {
   readonly proposedChangePlannedClosure: Locator
   readonly proposedChangeActualClosure: Locator
   readonly proposedChangeUkTarget: Locator
+  readonly directChangeStatus: Locator
+  readonly directChangePlannedOpening: Locator
+  readonly directChangeActualOpening: Locator
+  readonly directChangePlannedClosure: Locator
+  readonly directChangeActualClosure: Locator
+  readonly directChangeUkTarget: Locator
 
   //Initialize Page Objects
   constructor(page: Page) {
@@ -172,7 +178,7 @@ export default class StudyDetailsPage {
     this.secondSponsorAssessmentFurtherInfoBullets = this.secondSponsorAssessmentFurtherInfo.locator('ul li')
     this.firstSponsorAssessmentFurtherInfoText = this.firstSponsorAssessmentFurtherInfo.locator('p')
     this.secondSponsorAssessmentFurtherInfoText = this.secondSponsorAssessmentFurtherInfo.locator('p')
-    this.sponsorAssessmentHistory = page.locator('[class="govuk-!-margin-bottom-6"]') // TODO: temp fix need to use data-testid
+    this.sponsorAssessmentHistory = page.locator('[class="govuk-!-margin-bottom-6"]')
     this.firstSponsorAssessmentRow = this.sponsorAssessmentHistory.locator('button')
     this.secondSponsorAssessmentRow = this.sponsorAssessmentHistory.locator('button').nth(1)
     this.firstSponsorAssessmentDate = this.firstSponsorAssessmentRow.locator('div')
@@ -190,7 +196,7 @@ export default class StudyDetailsPage {
     this.allStudiesLink = page.locator('a[href="/studies"]')
     this.updateSuccessBanner = page.locator('.govuk-notification-banner.govuk-notification-banner--success')
     this.updateSuccessContent = page.locator('.govuk-notification-banner__heading')
-    this.viewEditHistory = page.locator('.govuk-details__summary').first()
+    this.viewEditHistory = page.locator('span:has-text("View edit history")')
     this.proposedChangeEditHistory = page.locator('[data-state="open"][data-testid^="edit-history-accordion-item-"]')
     this.proposedChangeUser = this.proposedChangeEditHistory.locator('span > span')
     this.proposedChangeStatus = this.proposedChangeEditHistory.locator('li:has-text("Study status changed from ")')
@@ -206,9 +212,23 @@ export default class StudyDetailsPage {
     this.proposedChangeActualClosure = this.proposedChangeEditHistory.locator(
       'li:has-text("Actual closure to recruitment date")'
     )
-    this.proposedChangeUkTarget = this.proposedChangeEditHistory.locator('li:has-text("UK recruitment target")').last()
-    this.directChangeEditHistory = this.proposedChangeEditHistory
-    this.directChangeUser = this.proposedChangeEditHistory.locator('span > span')
+    this.proposedChangeUkTarget = this.proposedChangeEditHistory.locator('li:has-text("UK recruitment target")')
+    this.directChangeEditHistory = page.locator('[data-testid^="edit-history-accordion-item-"]').first()
+    this.directChangeUser = this.directChangeEditHistory.locator('span > span')
+    this.directChangeStatus = this.proposedChangeEditHistory.locator('li:has-text("Study status changed from ")')
+    this.directChangePlannedOpening = this.directChangeEditHistory.locator(
+      'li:has-text("Planned opening to recruitment date")'
+    )
+    this.directChangeActualOpening = this.directChangeEditHistory.locator(
+      'li:has-text("Actual opening to recruitment date")'
+    )
+    this.directChangePlannedClosure = this.directChangeEditHistory.locator(
+      'li:has-text("Planned closure to recruitment date")'
+    )
+    this.directChangeActualClosure = this.directChangeEditHistory.locator(
+      'li:has-text("Actual closure to recruitment date")'
+    )
+    this.directChangeUkTarget = this.directChangeEditHistory.locator('li:has-text("UK recruitment target")')
   }
 
   //Page Methods
@@ -731,16 +751,11 @@ export default class StudyDetailsPage {
     }
   }
 
-  async assertStudyDetailsEditHistory(updateType: string, newValue: string, added: boolean) {
-    // Study status changed from ${old} to ${new}
-    // ${date} changed from ${old} to ${new} || ${date} ${new} added
-    // UK recruitment target changed from ${old} to ${new} || UK recruitment target ${new} added
-
+  async assertStudyDetailsEditHistory(updateType: string, oldValue: string, newValue: string, added: boolean) {
     switch (updateType) {
       case 'status':
         await expect(this.proposedChangeStatus).toBeVisible()
-        await expect(this.proposedChangeStatus).toContainText(`Study status changed from`)
-        await expect(this.proposedChangeStatus).toContainText(newValue)
+        await expect(this.proposedChangeStatus).toContainText(`Study status changed from ${oldValue} to ${newValue}`)
         break
       case 'plannedOpening':
         await expect(this.proposedChangePlannedOpening).toBeVisible()
@@ -750,9 +765,8 @@ export default class StudyDetailsPage {
           )
         } else {
           await expect(this.proposedChangePlannedOpening).toContainText(
-            `Planned opening to recruitment date changed from `
+            `Planned opening to recruitment date changed from ${oldValue} to ${newValue}`
           )
-          await expect(this.proposedChangePlannedOpening).toContainText(newValue)
         }
         await expect(this.proposedChangePlannedOpening).toContainText(newValue)
         break
@@ -764,9 +778,8 @@ export default class StudyDetailsPage {
           )
         } else {
           await expect(this.proposedChangeActualOpening).toContainText(
-            `Actual opening to recruitment date changed from `
+            `Actual opening to recruitment date changed from ${oldValue} to ${newValue}`
           )
-          await expect(this.proposedChangeActualOpening).toContainText(newValue)
         }
         break
       case 'plannedClosure':
@@ -776,9 +789,8 @@ export default class StudyDetailsPage {
           )
         } else {
           await expect(this.proposedChangePlannedClosure).toContainText(
-            `Planned closure to recruitment date changed from `
+            `Planned closure to recruitment date changed from ${oldValue} to ${newValue}`
           )
-          await expect(this.proposedChangePlannedClosure).toContainText(newValue)
         }
         break
       case 'actualClosure':
@@ -788,9 +800,8 @@ export default class StudyDetailsPage {
           )
         } else {
           await expect(this.proposedChangeActualClosure).toContainText(
-            `Actual closure to recruitment date changed from `
+            `Actual closure to recruitment date changed from ${oldValue} to ${newValue}`
           )
-          await expect(this.proposedChangeActualClosure).toContainText(newValue)
         }
         break
       // case 'estimatedReopening':
@@ -799,8 +810,9 @@ export default class StudyDetailsPage {
         if (added == true) {
           await expect(this.proposedChangeUkTarget).toContainText(`UK recruitment target ${newValue} added`)
         } else {
-          await expect(this.proposedChangeUkTarget).toContainText(`UK recruitment target changed from`)
-          await expect(this.proposedChangeUkTarget).toContainText(newValue)
+          await expect(this.proposedChangeUkTarget).toContainText(
+            `UK recruitment target changed from ${oldValue} to ${newValue}`
+          )
         }
         break
       default:

--- a/packages/qa/pages/StudyDetailsPage.ts
+++ b/packages/qa/pages/StudyDetailsPage.ts
@@ -804,8 +804,6 @@ export default class StudyDetailsPage {
           )
         }
         break
-      // case 'estimatedReopening':
-      //   break
       case 'ukTarget':
         if (added == true) {
           await expect(this.proposedChangeUkTarget).toContainText(`UK recruitment target ${newValue} added`)

--- a/packages/qa/pages/StudyUpdatePage.ts
+++ b/packages/qa/pages/StudyUpdatePage.ts
@@ -487,8 +487,8 @@ export default class StudyUpdatePage {
         await expect(this.updateValidationList).toContainText(`Enter a valid UK target`)
         break
       case 'null':
-        await expect(this.ukRecruitmentTargetInlineError).toHaveText(`Error: ???`)
-        await expect(this.updateValidationList).toContainText(`???`)
+        await expect(this.ukRecruitmentTargetInlineError).toHaveText(`Error: UK target is a mandatory field`)
+        await expect(this.updateValidationList).toContainText(`UK target is a mandatory field`)
         break
       default:
         throw new Error(`${error} is not a validation option`)

--- a/packages/qa/tests/features/studyUpdateTests/studyUpdateSubmitTest.e2e.ts
+++ b/packages/qa/tests/features/studyUpdateTests/studyUpdateSubmitTest.e2e.ts
@@ -4,7 +4,7 @@ import { cpmsDatabaseReq, seDatabaseReq, waitForSeDbRequest } from '../../../uti
 import { convertIsoDateToDisplayDateV2, splitIsoDate } from '../../../utils/UtilFunctions'
 
 const testUserId = 6
-const startingOrgId = 2
+const startingOrgId = 9
 const user = 'sesponsorcontact@test.id.nihr.ac.uk'
 
 // date variables for updating study dates and creating unique values
@@ -28,34 +28,44 @@ let uniqueTarget = timeStamp.slice(11, 19).replace(/:/g, '')
 if (uniqueTarget.startsWith('0')) {
   uniqueTarget = uniqueTarget.slice(1)
 }
+// old values for edit history from to assertions
+const oldDate = '2002-06-12'
+const oldTarget = '12345'
 
 let startingStudyId = 0
 let studyCoreDetails: RowDataPacket[]
 
 test.beforeAll('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
-
-  const randomStudyIdSelected = await seDatabaseReq(`
-    SELECT Study.id FROM Study 
-    INNER JOIN StudyOrganisation ON Study.id = StudyOrganisation.studyId
-    WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 AND Study.isDeleted = 0
-    AND Study.studyStatus = 'In Setup, Pending Approval'
-    ORDER BY RAND() LIMIT 1;
-  `)
-  startingStudyId = randomStudyIdSelected[0].id
-
-  studyCoreDetails = await seDatabaseReq(`
-    SELECT cpmsId, route FROM sponsorengagement.Study where id = ${startingStudyId};
-  `)
 })
 
-test.describe('Update study and save changes locally in SE @se_184', () => {
+test.describe('Update study and save changes locally in SE @se_184 @se_168', () => {
   test.use({ storageState: '.auth/sponsorContact.json' })
 
-  test('As a sponsor contact I can make proposed changed to the study data @se_184_proposed', async ({
+  test('As a sponsor contact I can make proposed changes to the study data (added history) @se_184_proposed @se_168_added', async ({
     studyUpdatePage,
     studyDetailsPage,
   }) => {
+    const randomStudyIdSelected = await seDatabaseReq(`
+      SELECT Study.id FROM Study 
+        INNER JOIN StudyOrganisation ON Study.id = StudyOrganisation.studyId
+        WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 AND Study.isDeleted = 0
+        AND Study.studyStatus = 'In Setup, Pending Approval'
+      ORDER BY RAND() LIMIT 1;
+    `)
+    startingStudyId = randomStudyIdSelected[0].id
+    studyCoreDetails = await seDatabaseReq(
+      `SELECT cpmsId, route FROM sponsorengagement.Study where id = ${startingStudyId};`
+    )
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[StudyStatusAudit]
+      SET 
+        [StatusId] = 3,
+        [DetailId] = 1,
+        [ReasonNote] = NULL,
+        [ModifiedDate] = '2020-01-01'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // reset status in cpms
     await cpmsDatabaseReq(`
       UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[Study]
       SET 
@@ -75,7 +85,7 @@ test.describe('Update study and save changes locally in SE @se_184', () => {
       await studyUpdatePage.goto(startingStudyId.toString())
     })
 
-    await test.step(`When I update the study details with a proposed status change`, async () => {
+    await test.step(`When I update the study details with a proposed changes`, async () => {
       await studyUpdatePage.statusRadioClosed.click()
       await studyUpdatePage.fillStudyDates('plannedOpening', po.d, po.m, po.y)
       await studyUpdatePage.fillStudyDates('actualOpening', ao.d, ao.m, ao.y)
@@ -96,41 +106,164 @@ test.describe('Update study and save changes locally in SE @se_184', () => {
       await studyDetailsPage.assertStudyUpdatedSuccess('proposed')
     })
 
-    await test.step(`And I should see my proposed changes study details edit history`, async () => {
+    await test.step(`And I should see my proposed changes as 'added' in the edit history`, async () => {
       const added = true
 
       await expect(studyDetailsPage.proposedChangeEditHistory).toBeVisible()
       await expect(studyDetailsPage.proposedChangeUser).toContainText(`Proposed change submitted by ${user}`)
 
-      await studyDetailsPage.assertStudyDetailsEditHistory('status', 'Closed', added)
+      await studyDetailsPage.assertStudyDetailsEditHistory('status', 'In setup', 'Closed', added)
       await studyDetailsPage.assertStudyDetailsEditHistory(
         'plannedOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
         convertIsoDateToDisplayDateV2(new Date(plannedOpen)),
         added
       )
       await studyDetailsPage.assertStudyDetailsEditHistory(
         'actualOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
         convertIsoDateToDisplayDateV2(new Date(actualOpen)),
         added
       )
       await studyDetailsPage.assertStudyDetailsEditHistory(
         'plannedClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
         convertIsoDateToDisplayDateV2(new Date(plannedClose)),
         added
       )
       await studyDetailsPage.assertStudyDetailsEditHistory(
         'actualClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
         convertIsoDateToDisplayDateV2(new Date(actualClose)),
         added
       )
-      await studyDetailsPage.assertStudyDetailsEditHistory('ukTarget', uniqueTarget, added)
+      await studyDetailsPage.assertStudyDetailsEditHistory('ukTarget', oldTarget, uniqueTarget, added)
     })
   })
 
-  test('As a sponsor contact I can make direct changes to the study data @se_184_direct', async ({
+  test('As a sponsor contact I can make proposed changes to the study data (updated history) @se_184_proposed @se_168_updated', async ({
     studyUpdatePage,
     studyDetailsPage,
   }) => {
+    const randomStudyIdSelected = await seDatabaseReq(`
+      SELECT Study.id FROM Study 
+        INNER JOIN StudyOrganisation ON Study.id = StudyOrganisation.studyId
+        WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 AND Study.isDeleted = 0
+        AND Study.studyStatus = 'In Setup, Pending Approval'
+      ORDER BY RAND() LIMIT 1;
+    `)
+    startingStudyId = randomStudyIdSelected[0].id
+    studyCoreDetails = await seDatabaseReq(
+      `SELECT cpmsId, route FROM sponsorengagement.Study where id = ${startingStudyId};`
+    )
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[StudyStatusAudit]
+      SET 
+        [StatusId] = 3,
+        [DetailId] = 1,
+        [ReasonNote] = NULL,
+        [ModifiedDate] = '2020-01-01'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // reset status in cpms
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[Study]
+      SET 
+        [PlannedRecruitmentStartDate] = '${oldDate}',
+        [PlannedRecruitmentEndDate] = '${oldDate}',
+        [ActualOpeningDate] = '${oldDate}',
+        [ActualClosureDate] = '${oldDate}',
+        [UkRecruitmentSampleSize] = '${oldTarget}',
+        [NetworkRecruitmentSampleSize] = '${oldTarget}'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // resets values in cpms to base values
+    await seDatabaseReq(`
+      DELETE FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId};
+    `) // resets study updates in se
+
+    await test.step(`Given I have navigated to the Update study data page for the Study with SE Id ${startingStudyId}`, async () => {
+      await studyUpdatePage.goto(startingStudyId.toString())
+    })
+
+    await test.step(`When I update the study details with a proposed changes`, async () => {
+      await studyUpdatePage.statusRadioClosed.click()
+      await studyUpdatePage.fillStudyDates('plannedOpening', po.d, po.m, po.y)
+      await studyUpdatePage.fillStudyDates('actualOpening', ao.d, ao.m, ao.y)
+      await studyUpdatePage.fillStudyDates('plannedClosure', pc.d, pc.m, pc.y)
+      await studyUpdatePage.fillStudyDates('actualClosure', ac.d, ac.m, ac.y)
+      await studyUpdatePage.ukRecruitmentTarget.fill(uniqueTarget)
+      await studyUpdatePage.furtherInfo.fill(`se e2e auto test - ${timeStamp}`)
+      await studyUpdatePage.buttonUpdate.click()
+      await studyUpdatePage.assertUpdatingMessage()
+    })
+
+    await test.step(`Then I should see that my changes have been saved as proposed changes`, async () => {
+      const dbStudyUpdate = await waitForSeDbRequest(
+        `SELECT * FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId} ORDER by createdAt LIMIT 2;`
+      )
+
+      await studyUpdatePage.assertSeDbUpdateProposed(dbStudyUpdate[1], timeStamp)
+      await studyDetailsPage.assertStudyUpdatedSuccess('proposed')
+    })
+
+    await test.step(`And I should see my proposed changes as 'updated' in the edit history`, async () => {
+      const added = false
+
+      await expect(studyDetailsPage.proposedChangeEditHistory).toBeVisible()
+      await expect(studyDetailsPage.proposedChangeUser).toContainText(`Proposed change submitted by ${user}`)
+
+      await studyDetailsPage.assertStudyDetailsEditHistory('status', 'In setup', 'Closed', added)
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedOpen)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'actualOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(actualOpen)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedClose)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'actualClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(actualClose)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory('ukTarget', oldTarget, uniqueTarget, added)
+    })
+  })
+
+  test('As a sponsor contact I can make direct changes to the study data (added history) @se_184_direct @se_168_added', async ({
+    studyUpdatePage,
+    studyDetailsPage,
+  }) => {
+    const randomStudyIdSelected = await seDatabaseReq(`
+      SELECT Study.id FROM Study 
+        INNER JOIN StudyOrganisation ON Study.id = StudyOrganisation.studyId
+        WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 AND Study.isDeleted = 0
+        AND Study.studyStatus = 'In Setup, Pending Approval'
+      ORDER BY RAND() LIMIT 1;
+    `)
+    startingStudyId = randomStudyIdSelected[0].id
+    studyCoreDetails = await seDatabaseReq(
+      `SELECT cpmsId, route FROM sponsorengagement.Study where id = ${startingStudyId};`
+    )
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[StudyStatusAudit]
+      SET 
+        [StatusId] = 3,
+        [DetailId] = 1,
+        [ReasonNote] = NULL,
+        [ModifiedDate] = '2020-01-01'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // reset status in cpms
     await cpmsDatabaseReq(`
       UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[Study]
       SET 
@@ -174,11 +307,120 @@ test.describe('Update study and save changes locally in SE @se_184', () => {
       await studyDetailsPage.assertUkTarget(parseInt(uniqueTarget), studyCoreDetails[0].route)
     })
 
-    await test.step(`And I should see my changes under View edit history`, async () => {
-      // await expect(studyDetailsPage.directChangeEditHistory).toContainText(`View edit history`)
-      // await studyDetailsPage.directChangeEditHistory.click()
-      // await expect(studyDetailsPage.proposedChangeEditHistory).toBeVisible()
-      // await expect(studyDetailsPage.directChangeUser).toContainText(`Change made by ${user}`)
+    await test.step(`And I should see my direct changes as 'added' in the edit history`, async () => {
+      const added = true
+
+      await expect(studyDetailsPage.viewEditHistory).toContainText(`View edit history`)
+      await studyDetailsPage.viewEditHistory.click()
+      await expect(studyDetailsPage.directChangeEditHistory).toBeVisible()
+      await expect(studyDetailsPage.directChangeUser).toContainText(`Change made by ${user}`)
+      await studyDetailsPage.directChangeEditHistory.click()
+
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedOpen)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedClose)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory('ukTarget', oldTarget, uniqueTarget, added)
+    })
+  })
+
+  test('As a sponsor contact I can make direct changes to the study data (updated history) @se_184_direct @se_168_updated', async ({
+    studyUpdatePage,
+    studyDetailsPage,
+  }) => {
+    const randomStudyIdSelected = await seDatabaseReq(`
+      SELECT Study.id FROM Study 
+        INNER JOIN StudyOrganisation ON Study.id = StudyOrganisation.studyId
+        WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 AND Study.isDeleted = 0
+        AND Study.studyStatus = 'In Setup, Pending Approval'
+      ORDER BY RAND() LIMIT 1;
+    `)
+    startingStudyId = randomStudyIdSelected[0].id
+    studyCoreDetails = await seDatabaseReq(
+      `SELECT cpmsId, route FROM sponsorengagement.Study where id = ${startingStudyId};`
+    )
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[StudyStatusAudit]
+      SET 
+        [StatusId] = 3,
+        [DetailId] = 1,
+        [ReasonNote] = NULL,
+        [ModifiedDate] = '2020-01-01'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // reset status in cpms
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[Study]
+      SET 
+        [PlannedRecruitmentStartDate] = '${oldDate}',
+        [PlannedRecruitmentEndDate] = '${oldDate}',
+        [ActualOpeningDate] = '${oldDate}',
+        [ActualClosureDate] = '${oldDate}',
+        [UkRecruitmentSampleSize] = '${oldTarget}',
+        [NetworkRecruitmentSampleSize] = '${oldTarget}'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `)
+    await seDatabaseReq(`
+      DELETE FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId};
+    `)
+
+    await test.step(`Given I have navigated to the Update study data page for the Study with SE Id ${startingStudyId}`, async () => {
+      await studyUpdatePage.goto(startingStudyId.toString())
+    })
+
+    await test.step(`When I update the study details without changing the status`, async () => {
+      await studyUpdatePage.fillStudyDates('plannedOpening', po.d, po.m, po.y)
+      await studyUpdatePage.fillStudyDates('plannedClosure', pc.d, pc.m, pc.y)
+      await studyUpdatePage.ukRecruitmentTarget.fill(uniqueTarget)
+      await studyUpdatePage.furtherInfo.fill(`se e2e auto test - ${timeStamp}`)
+      await studyUpdatePage.buttonUpdate.click()
+      await studyUpdatePage.assertUpdatingMessage()
+    })
+
+    await test.step(`Then I should see that my changes have been saved as direct changes`, async () => {
+      const dbStudyUpdate = await waitForSeDbRequest(
+        `SELECT * FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId} ORDER by createdAt LIMIT 2;`
+      )
+
+      await studyUpdatePage.assertSeDbUpdateDirect(dbStudyUpdate[1], timeStamp)
+      await studyDetailsPage.assertStudyUpdatedSuccess('direct')
+    })
+
+    await test.step(`And I should see that my direct changes are reflected on the study details page`, async () => {
+      await studyDetailsPage.assertPlannedOpeningDateV2(new Date(plannedOpen))
+      await studyDetailsPage.assertPlannedClosureDateV2(new Date(plannedClose))
+      await studyDetailsPage.assertUkTarget(parseInt(uniqueTarget), studyCoreDetails[0].route)
+    })
+
+    await test.step(`And I should see my direct changes as 'updated' in the edit history`, async () => {
+      const added = false
+
+      await expect(studyDetailsPage.viewEditHistory).toContainText(`View edit history`)
+      await studyDetailsPage.viewEditHistory.click()
+      await expect(studyDetailsPage.directChangeEditHistory).toBeVisible()
+      await expect(studyDetailsPage.directChangeUser).toContainText(`Change made by ${user}`)
+      await studyDetailsPage.directChangeEditHistory.click()
+
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedOpening',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedOpen)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory(
+        'plannedClosure',
+        convertIsoDateToDisplayDateV2(new Date(oldDate)),
+        convertIsoDateToDisplayDateV2(new Date(plannedClose)),
+        added
+      )
+      await studyDetailsPage.assertStudyDetailsEditHistory('ukTarget', oldTarget, uniqueTarget, added)
     })
   })
 })

--- a/packages/qa/tests/features/studyUpdateTests/studyUpdateValidationTest.e2e.ts
+++ b/packages/qa/tests/features/studyUpdateTests/studyUpdateValidationTest.e2e.ts
@@ -36,7 +36,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '66', '01', '2024')
       await studyUpdatePage.fillStudyDates('plannedClosure', '66', '01', '2024')
       await studyUpdatePage.fillStudyDates('actualClosure', '66', '01', '2024')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -68,7 +68,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '02', '24', '2024')
       await studyUpdatePage.fillStudyDates('plannedClosure', '03', '13', '2024')
       await studyUpdatePage.fillStudyDates('actualClosure', '04', '25', '2024')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -100,7 +100,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '03', '04', '99999')
       await studyUpdatePage.fillStudyDates('plannedClosure', '05', '06', '999')
       await studyUpdatePage.fillStudyDates('actualClosure', '07', '08', '99')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -133,7 +133,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('plannedOpening', '', '02', '2024')
       await studyUpdatePage.fillStudyDates('actualOpening', '01', '', '2024')
       await studyUpdatePage.fillStudyDates('plannedClosure', '01', '02', '')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -166,7 +166,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '29', '02', '2023')
       await studyUpdatePage.fillStudyDates('plannedClosure', '29', '02', '2023')
       await studyUpdatePage.fillStudyDates('actualClosure', '29', '02', '2023')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -231,7 +231,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
     })
   })
 
-  test.skip('Validation error message for Null UK target validation @se_217', async ({ studyUpdatePage }) => {
+  test('Validation error message for Null UK target validation @se_217', async ({ studyUpdatePage }) => {
     await seDatabaseReq(`
       DELETE FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId};
     `)
@@ -270,7 +270,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '2', '2', '2024')
       await studyUpdatePage.fillStudyDates('plannedClosure', '2', '2', '2023')
       await studyUpdatePage.fillStudyDates('actualClosure', '2', '2', '2024')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -300,7 +300,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '2', '2', '2027')
       await studyUpdatePage.fillStudyDates('plannedClosure', '1', '1', '2027')
       await studyUpdatePage.fillStudyDates('actualClosure', '1', '1', '2024')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 
@@ -330,7 +330,7 @@ test.describe('Validation rules for auto & proposed study updates @se_183', () =
       await studyUpdatePage.fillStudyDates('actualOpening', '2', '2', '2024')
       await studyUpdatePage.fillStudyDates('plannedClosure', '1', '1', '2027')
       await studyUpdatePage.fillStudyDates('actualClosure', '1', '1', '2027')
-      await studyUpdatePage.ukRecruitmentTarget.fill('')
+      await studyUpdatePage.ukRecruitmentTarget.fill('101')
       await studyUpdatePage.furtherInfo.fill(``)
     })
 

--- a/packages/qa/tests/features/studyUpdateTests/studyUpdateWithCpmsTest.e2e.ts
+++ b/packages/qa/tests/features/studyUpdateTests/studyUpdateWithCpmsTest.e2e.ts
@@ -1,12 +1,29 @@
 import { RowDataPacket } from 'mysql2'
 import { test, expect } from '../../../hooks/CustomFixtures'
-import { seDatabaseReq, waitForSeDbRequest } from '../../../utils/DbRequests'
+import { seDatabaseReq, waitForSeDbRequest, cpmsDatabaseReq } from '../../../utils/DbRequests'
 import { convertIsoDateToDisplayDateV2, splitIsoDate } from '../../../utils/UtilFunctions'
 
 const testUserId = 6
 const startingOrgId = 2
-const timeStamp = new Date().toISOString()
-let uniqueTarget = new Date().toISOString().slice(11, 19).replace(/:/g, '')
+
+// date variables for updating study dates and creating unique values
+const today = new Date()
+const timeStamp = today.toISOString()
+const yy = today.getFullYear()
+const mm = String(today.getMonth() + 1).padStart(2, '0')
+const dd = String(today.getDate()).padStart(2, '0')
+// creating iso date strings
+const plannedOpen = `${yy}-${mm}-${dd}`
+const actualOpen = `${yy}-${mm}-${dd}`
+const plannedClose = `${yy + 1}-${mm}-${dd}` // +1 year
+const actualClose = `${yy}-${mm}-${dd}`
+// splitting iso dates
+const po = splitIsoDate(plannedOpen)
+const ao = splitIsoDate(actualOpen)
+const pc = splitIsoDate(plannedClose)
+const ac = splitIsoDate(actualClose)
+// unique target values based on current hhmmss
+let uniqueTarget = timeStamp.slice(11, 19).replace(/:/g, '')
 if (uniqueTarget.startsWith('0')) {
   uniqueTarget = uniqueTarget.slice(1)
 }
@@ -14,10 +31,6 @@ if (uniqueTarget.startsWith('0')) {
 let startingStudyId = 0
 let studyCoreDetails: RowDataPacket[]
 
-const plannedOpen = '2025-06-12'
-const plannedClose = '2027-06-12'
-const po = splitIsoDate(plannedOpen)
-const pc = splitIsoDate(plannedClose)
 const pOpen = new Date(plannedOpen)
 const pClose = new Date(plannedClose)
 
@@ -43,6 +56,26 @@ test.describe('Sponsor engagement study update with CPMS study validation @se_to
   test.describe.configure({ timeout: 99000 }) // generous timeout as CPMS is slow!
 
   test('direct SE change with CPMS validation @se_to_cpms_1', async ({ browser }) => {
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[StudyStatusAudit]
+      SET 
+        [StatusId] = 3,
+        [DetailId] = 1,
+        [ReasonNote] = NULL,
+        [ModifiedDate] = '2020-01-01'
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `) // reset status in cpms
+    await cpmsDatabaseReq(`
+      UPDATE [NIHR.CRN.CPMS.OperationalDatabase].[dbo].[Study]
+      SET 
+        [PlannedRecruitmentStartDate] = NULL,
+        [PlannedRecruitmentEndDate] = NULL,
+        [ActualOpeningDate] = NULL,
+        [ActualClosureDate] = NULL,
+        [UkRecruitmentSampleSize] = NULL,
+        [NetworkRecruitmentSampleSize] = NULL
+      WHERE [Id] = ${studyCoreDetails[0].cpmsId};  
+    `)
     await seDatabaseReq(`
       DELETE FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId};
     `) // reset test data
@@ -107,12 +140,10 @@ test.describe('Sponsor engagement study update with CPMS study validation @se_to
       await expect(cpmsPage.locator('#CurrentStudyRecord_UkRecruitmentSampleSize')).toHaveValue(uniqueTarget)
       await expect(cpmsPage.locator('#CurrentStudyRecord_PlannedRecruitmentStartDate')).toHaveAttribute(
         'value',
-        // /12\/06\/2025/
         new RegExp(`${po.d}\/${po.m}\/${po.y}`)
       )
       await expect(cpmsPage.locator('#CurrentStudyRecord_PlannedRecruitmentEndDate')).toHaveAttribute(
         'value',
-        // /12\/06\/2027/
         new RegExp(`${pc.d}\/${pc.m}\/${pc.y}`)
       )
     })
@@ -120,101 +151,6 @@ test.describe('Sponsor engagement study update with CPMS study validation @se_to
     await test.step(`And I save the study in CPMS`, async () => {
       await cpmsPage.locator('#btnSaveStudy').click()
       await cpmsPage.waitForTimeout(15000) // explicity as unable to await request on save
-    })
-
-    await test.step(`Then I should not see any save errors`, async () => {
-      await expect(cpmsPage.locator('#failuremessage')).not.toBeVisible
-    })
-
-    // close cpms context
-    await cpmsPage.close()
-    await cpmsContext.close()
-  })
-
-  test.skip('proposed SE change with CPMS validation', async ({ browser }) => {
-    await seDatabaseReq(`
-      DELETE FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId};
-    `) // reset test data
-
-    // use se sponsor contact context
-    const seContext = await browser.newContext({ storageState: '.auth/sponsorContact.json' })
-    const sePage = await seContext.newPage()
-
-    await test.step(`Given I have navigated to the Update study data page for the Study with SE Id ${startingStudyId}`, async () => {
-      await sePage.goto(`studies/${startingStudyId}/edit`)
-      await expect(sePage.locator('.govuk-inset-text')).toBeVisible()
-    })
-
-    await test.step(`And I update the study details with proposed changes`, async () => {
-      async function fillStudyDates(dateType: string, dd: string, mm: string, yyyy: string) {
-        await sePage.locator(`#${dateType}Date-day`).fill(dd)
-        await sePage.locator(`#${dateType}Date-month`).fill(mm)
-        await sePage.locator(`#${dateType}Date-year`).fill(yyyy)
-      }
-
-      // await sePage.locator('#status-3').click()
-      await fillStudyDates('plannedOpening', '12', '06', '2025')
-      await fillStudyDates('actualOpening', '12', '06', '2024')
-      await fillStudyDates('plannedClosure', '12', '06', '2027')
-      await fillStudyDates('actualClosure', '12', '06', '2024')
-      await sePage.locator('#recruitmentTarget').fill(uniqueTarget)
-      await sePage.locator('#furtherInformation').fill(`se e2e auto test - ${timeStamp}`)
-      await sePage.locator('button.govuk-button:has-text("Update")').click()
-      await expect(sePage.locator('.govuk-warning-text__text')).toHaveText(
-        'It may take a few seconds for the record to update. Please stay on this page until redirected.'
-      )
-    })
-
-    await test.step(`And I see the study is successfully updated in SE`, async () => {
-      const dbStudyUpdate = await waitForSeDbRequest(
-        `SELECT * FROM sponsorengagement.StudyUpdates WHERE studyId = ${startingStudyId} ORDER by createdAt LIMIT 2;`
-      )
-
-      await expect(sePage.locator('.govuk-notification-banner__heading')).toHaveText(
-        'Your study data changes have been accepted.'
-      )
-
-      await expect(dbStudyUpdate[1].studyStatus).toBeNull()
-      await expect(dbStudyUpdate[1].comment).toBe(`se e2e auto test - ${timeStamp}`)
-      await expect(dbStudyUpdate[1].studyStatusGroup).toBe('Closed')
-    })
-
-    // close se context
-    await sePage.close()
-    await seContext.close()
-
-    // use cpms npm context
-    const cpmsContext = await browser.newContext({ storageState: '.auth/nationalPortfolioManager.json' })
-    const cpmsPage = await cpmsContext.newPage()
-
-    await test.step(`When I navigate to the edit view for the study in CPMS`, async () => {
-      const id = studyCoreDetails[0].cpmsId
-
-      await cpmsPage.goto(`https://test.cpms.crncc.nihr.ac.uk/Base/StudyRecord/Edit/${id}?selectedTab=1`)
-      await expect(cpmsPage.locator('.breadcrumbs')).toBeVisible()
-      await expect(cpmsPage.locator('.breadcrumbs')).toContainText(`CPMS ID: ${id}`)
-    })
-
-    await test.step(`And I see my expected study details in CPMS`, async () => {
-      await expect(cpmsPage.locator('#CurrentStudyRecord_UkRecruitmentSampleSize')).toHaveValue(uniqueTarget)
-      await expect(cpmsPage.locator('#CurrentStudyRecord_PlannedRecruitmentStartDate')).toHaveAttribute(
-        'value',
-        /12\/06\/2025/
-      )
-      await expect(cpmsPage.locator('#CurrentStudyRecord_ActualOpeningDate')).toHaveAttribute('value', /12\/06\/2024/)
-      await expect(cpmsPage.locator('#CurrentStudyRecord_PlannedRecruitmentEndDate')).toHaveAttribute(
-        'value',
-        /12\/06\/2022/
-      )
-      await expect(cpmsPage.locator('#CurrentStudyRecord_ActualRecruitmentEndDate')).toHaveAttribute(
-        'value',
-        /12\/06\/2025/
-      )
-    })
-
-    await test.step(`And I save the study in CPMS`, async () => {
-      await cpmsPage.locator('#btnSaveStudy').click()
-      await cpmsPage.waitForTimeout(15000) // unable to await request on save
     })
 
     await test.step(`Then I should not see any save errors`, async () => {

--- a/packages/qa/utils/dbConfig.ts
+++ b/packages/qa/utils/dbConfig.ts
@@ -1,23 +1,52 @@
 import mysql, { PoolOptions } from 'mysql2'
 import sql from 'mssql'
 
-// this was refactored to use a connection pool for automatic reconnection and scalability as the original db connection was flaky
-// this should ensure that the db connection is available throughout the entirety of the test execution without being prematurely closed
+// this was refactored to use a connection pools for automatic reconnection and scalability as the original db connection was flaky
+// this should ensure that the db connection is available throughout the entirety of the test execution without being prematurely closed.
+// this also adds a dedicated pool for both se and cpms connections.
 
+// se env variables and checks
 const seServer =
   process.env.SE_TEST_DB_HOST ||
   (() => {
     throw new Error('SE_TEST_DB_HOST is not defined')
   })()
+
+const seUsername =
+  process.env.SE_TEST_DB_USERNAME ||
+  (() => {
+    throw new Error('SE_TEST_DB_USERNAME is not defined')
+  })()
+
 const sePassword =
   process.env.SE_TEST_DB_PASSWORD ||
   (() => {
     throw new Error('SE_TEST_DB_PASSWORD is not defined')
   })()
 
+// cpms env variables and checks
+const cpmsServer =
+  process.env.CPMS_TEST_DB_IP ||
+  (() => {
+    throw new Error('CPMS_TEST_DB_IP is not defined')
+  })()
+
+const cpmsUsername =
+  process.env.CPMS_TEST_DB_USERNAME ||
+  (() => {
+    throw new Error('CPMS_TEST_DB_USERNAME is not defined')
+  })()
+
+const cpmsPassword =
+  process.env.CPMS_TEST_DB_PASSWORD ||
+  (() => {
+    throw new Error('CPMS_TEST_DB_PASSWORD is not defined')
+  })()
+
+// see config object
 const seDbConfig: PoolOptions = {
   host: seServer,
-  user: 'admin',
+  user: seUsername,
   password: sePassword,
   database: 'sponsorengagement',
   connectTimeout: 30000,
@@ -25,6 +54,21 @@ const seDbConfig: PoolOptions = {
   connectionLimit: 10,
 }
 
+// cpms config object
+const cpmsDbConfig = {
+  server: cpmsServer,
+  port: 1433, // already default but set explicitly to avoid ci issues
+  database: 'NIHR.CRN.CPMS.OperationalDatabase',
+  user: cpmsUsername,
+  password: cpmsPassword,
+  options: {
+    encrypt: true,
+    trustServerCertificate: true,
+    trustedConnection: false,
+  },
+}
+
+// se connection pool
 function seCreatePool() {
   const pool = mysql.createPool(seDbConfig)
 
@@ -49,30 +93,7 @@ function seCreatePool() {
   return pool
 }
 
-const cpmsServer =
-  process.env.CPMS_TEST_DB_IP ||
-  (() => {
-    throw new Error('CPMS_TEST_DB_IP is not defined')
-  })()
-const cpmsPassword =
-  process.env.CPMS_TEST_DB_PASSWORD ||
-  (() => {
-    throw new Error('CPMS_TEST_DB_PASSWORD is not defined')
-  })()
-
-const cpmsDbConfig = {
-  server: cpmsServer,
-  port: 1433, // already default but setting explicitly to avoid ci issues
-  // database: 'NIHR.CRN.CPMS.OperationalDatabase',
-  user: 'cpmsadmin',
-  password: cpmsPassword,
-  options: {
-    encrypt: true,
-    trustServerCertificate: true,
-    trustedConnection: false,
-  },
-}
-
+// cpms connection pool
 function cpmsCreatePool() {
   const pool = new sql.ConnectionPool(cpmsDbConfig)
   const poolConnect = pool

--- a/packages/qa/utils/dbConfig.ts
+++ b/packages/qa/utils/dbConfig.ts
@@ -1,9 +1,9 @@
 import mysql, { PoolOptions } from 'mysql2'
 import sql from 'mssql'
 
-// this was refactored to use a connection pools for automatic reconnection and scalability as the original db connection was flaky
+// this was refactored to use a connection pool for automatic reconnection and scalability as the original db connection was flaky
 // this should ensure that the db connection is available throughout the entirety of the test execution without being prematurely closed.
-// this also adds a dedicated pool for both se and cpms connections.
+// this also adds a dedicated pool for both se and cpms db connections.
 
 // se env variables and checks
 const seServer =


### PR DESCRIPTION
- adds new tests for study edit history added & updated for proposed and direct changes
- un skips new validation tests for uk target
- enforces unique studies for update tests to avoid se cpms conflicts
- paramaterises test users and all db configs