### PR TITLE
Do not include deleted organisations for notify email

### DIFF
--- a/apps/notify/src/notify.ts
+++ b/apps/notify/src/notify.ts
@@ -36,6 +36,7 @@ const sendNotifications = async () => {
           some: {
             organisation: {
               studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              isDeleted: false,
             },
             isDeleted: false,
           },
@@ -49,6 +50,13 @@ const sendNotifications = async () => {
       },
       include: {
         organisations: {
+          where: {
+            organisation: {
+              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              isDeleted: false,
+            },
+            isDeleted: false,
+          },
           select: {
             organisation: {
               select: {
@@ -66,6 +74,7 @@ const sendNotifications = async () => {
           some: {
             organisation: {
               studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              isDeleted: false,
             },
             isDeleted: false,
           },
@@ -79,6 +88,13 @@ const sendNotifications = async () => {
       },
       include: {
         organisations: {
+          where: {
+            organisation: {
+              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              isDeleted: false,
+            },
+            isDeleted: false,
+          },
           select: {
             organisation: {
               select: {

--- a/apps/notify/src/tests/notify.spec.ts
+++ b/apps/notify/src/tests/notify.spec.ts
@@ -117,6 +117,13 @@ describe('notify', () => {
       where: expect.objectContaining({ email: { in: allowList } }),
       include: expect.objectContaining({
         organisations: {
+          where: {
+            organisation: {
+              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              isDeleted: false,
+            },
+            isDeleted: false,
+          },
           select: {
             organisation: {
               select: {


### PR DESCRIPTION
This PR ensures we do not include deleted organisations in the notify email.