### PR TITLE
e2e test clean up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -290,7 +290,7 @@ jobs:
           SE_TEST_API_URL: ${{ secrets.CPMS_API_BASE_URL }}
           SE_TEST_API_USERNAME: ${{ secrets.CPMS_API_USERNAME }}
           SE_TEST_API_PASSWORD: ${{ secrets.CPMS_API_PASSWORD }}
-          CPMS_TEST_DB_IP: ${{ secrets.CPMS_TEST_DB_IP }}
+          CPMS_TEST_DB_HOST: ${{ secrets.CPMS_TEST_DB_HOST }}
           CPMS_TEST_DB_USERNAME: ${{ secrets.CPMS_TEST_DB_USERNAME }}
           CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
         SE_TEST_API_URL: ${{ secrets.CPMS_API_BASE_URL }}
         SE_TEST_API_USERNAME: ${{ secrets.CPMS_API_USERNAME }}
         SE_TEST_API_PASSWORD: ${{ secrets.CPMS_API_PASSWORD }}
-        CPMS_TEST_DB_IP: ${{ secrets.CPMS_TEST_DB_IP }}
+        CPMS_TEST_DB_HOST: ${{ secrets.CPMS_TEST_DB_HOST }}
         CPMS_TEST_DB_USERNAME: ${{ secrets.CPMS_TEST_DB_USERNAME }}
         CPMS_TEST_DB_PASSWORD: ${{ secrets.CPMS_TEST_DB_PASSWORD }}
     

--- a/packages/qa/.env.example
+++ b/packages/qa/.env.example
@@ -1,5 +1,5 @@
 # env
-E2E_BASE_URL=https://test.assessmystudy.nihr.ac.uk/
+E2E_BASE_URL=
 
 # se db
 SE_TEST_DB_HOST=
@@ -7,24 +7,24 @@ SE_TEST_DB_USERNAME=
 SE_TEST_DB_PASSWORD=
 
 # cpms db
-CPMS_TEST_DB_IP=
+CPMS_TEST_DB_HOST=
 CPMS_TEST_DB_PASSWORD=
 CPMS_TEST_DB_USERNAME=
 
 # test user
-SPONSOR_CONTACT_USER=sesponsorcontact@test.id.nihr.ac.uk
+SPONSOR_CONTACT_USER=
 SPONSOR_CONTACT_PASS=
-SPONSOR_CONTACT_MANAGER_USER=sesponsorcontactmanager@test.id.nihr.ac.uk
+SPONSOR_CONTACT_MANAGER_USER=
 SPONSOR_CONTACT_MANAGER_PASS=
-CONTACT_MANAGER_USER=secontactmanager@test.id.nihr.ac.uk
+CONTACT_MANAGER_USER=
 CONTACT_MANAGER_PASS=
-SE_NO_LOCAL_ACCOUNT_USER=senolocalaccount@test.id.nihr.ac.uk
+SE_NO_LOCAL_ACCOUNT_USER=
 SE_NO_LOCAL_ACCOUNT_PASS=
-CPMS_NPM_USER=sim_auto_npm@test.id.nihr.ac.uk
+CPMS_NPM_USER=
 CPMS_NPM_PASS=
 
 # api
-SE_TEST_API_URL=https://test.cpmsapi.crncc.nihr.ac.uk/
+SE_TEST_API_URL=
 SE_TEST_API_USERNAME=
 SE_TEST_API_PASSWORD=
 

--- a/packages/qa/README.md
+++ b/packages/qa/README.md
@@ -4,11 +4,6 @@ Written in Typescript with Playwright using page object model & test steps.
 
 Playwright [Documentation](https://playwright.dev/docs/intro)
 
-## Authors
-
-- [Chris McNeill - PA Consulting](https://github.com/chrismcneill89)
-- [Adam Nicolaou-Jones - PA consulting](https://github.com/onlyadam)
-
 ## Setup
 
 Install Node on your local machine. e.g. If using a Mac `brew install node`  
@@ -28,32 +23,32 @@ Then populate the variables by retrieving from the following sources:
 
 ```text
   # env             # the SE environment you wish to test (currently only supports test)
-  E2E_BASE_URL=https://test.assessmystudy.nihr.ac.uk/
+  E2E_BASE_URL=
 
-  # test users      # creds can be found in https://docs.google.com/document/d/1J9I1b4hb28rd9vl34Oe7XPCeZqk8yVsyG84KJgXS6k0
-  SPONSOR_CONTACT_USER=sesponsorcontact@test.id.nihr.ac.uk
+  # test users
+  SPONSOR_CONTACT_USER=
   SPONSOR_CONTACT_PASS=
-  SPONSOR_CONTACT_MANAGER_USER=sesponsorcontactmanager@test.id.nihr.ac.uk
+  SPONSOR_CONTACT_MANAGER_USER=
   SPONSOR_CONTACT_MANAGER_PASS=
-  CONTACT_MANAGER_USER=secontactmanager@test.id.nihr.ac.uk
+  CONTACT_MANAGER_USER=
   CONTACT_MANAGER_PASS=
-  SE_NO_LOCAL_ACCOUNT_USER=senolocalaccount@test.id.nihr.ac.uk
+  SE_NO_LOCAL_ACCOUNT_USER=
   SE_NO_LOCAL_ACCOUNT_PASS=
-  CPMS_NPM_USER=sim_auto_npm@test.id.nihr.ac.uk
+  CPMS_NPM_USER=
   CPMS_NPM_PASS=
 
-  # se db           # creds can be found in https://docs.google.com/document/d/1J9I1b4hb28rd9vl34Oe7XPCeZqk8yVsyG84KJgXS6k0
+  # se db
   SE_TEST_DB_HOST=
   SE_TEST_DB_USERNAME
   SE_TEST_DB_PASSWORD=
 
-  # cpms db         # creds ask nihr-managed-services
+  # cpms db
   CPMS_TEST_DB_PASSWORD=
   CPMS_TEST_DB_USERNAME
-  CPMS_TEST_DB_IP=
+  CPMS_TEST_DB_HOST=
 
   # api
-  SE_TEST_API_URL=  # creds can be found in https://eu-west-2.console.aws.amazon.com/secretsmanager/secret?name=crnccd-secret-test-se-app-config&region=eu-west-2
+  SE_TEST_API_URL=
   SE_TEST_API_USERNAME=
   SE_TEST_API_PASSWORD=
 
@@ -141,8 +136,12 @@ This removes the risk of accidentally committing temporary config changes that m
 
 To enabled & execute the accessibility tests simply:
 
+1. Run `npm run test:axe` - runs sub shell so you don't need to worry about environment variables.
+
+or
+
 1. Add or uncomment `ENABLE_ACCESSIBILITY=true` in `packages/qa/.env`
-2. Run all test as normal with `npx playwright test` or just the accessibility tests with `npx playwright test --project=seDefault --grep "@accessibility"`
+2. Run all tests as normal with `npx playwright test` or just the accessibility tests with `npx playwright test --project=seDefault --grep "@accessibility"`
 3. After remember to comment out or remove `ENABLE_ACCESSIBILITY=true` in `packages/qa/.env`
 
 **Note:** You could also use any of the following to run the accessibility tests:

--- a/packages/qa/hooks/GlobalTeardown.ts
+++ b/packages/qa/hooks/GlobalTeardown.ts
@@ -5,6 +5,7 @@ async function globalTeardown() {
   unlinkSync('.auth/sponsorContact.json')
   unlinkSync('.auth/contactManager.json')
   unlinkSync('.auth/nationalPortfolioManager.json')
+  unlinkSync('.auth/consentCookie.json')
 }
 
 export default globalTeardown

--- a/packages/qa/package.json
+++ b/packages/qa/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "NODE_OPTIONS='--no-deprecation=DEP0123' playwright test --project=seDefault",
+    "test": "playwright test --project=seDefault",
     "test:android": "playwright test --project=seMobileAndroid",
     "test:axe": "(ENABLE_ACCESSIBILITY=true playwright test --project=seDefault --grep '@accessibility')",
     "test:chrome": "playwright test --project=seChrome",

--- a/packages/qa/tests/authSetup/auth.setup.e2e.ts
+++ b/packages/qa/tests/authSetup/auth.setup.e2e.ts
@@ -3,26 +3,29 @@ import { test as setup } from '../../hooks/CustomFixtures'
 const authSponsorContactFile = '.auth/sponsorContact.json'
 const authContactManagerFile = '.auth/contactManager.json'
 const authNpmFile = '.auth/nationalPortfolioManager.json'
+const cookieOnlyFile = '.auth/consentCookie.json'
+
 const cookieConfig = {
   name: 'SEConsentGDPR',
   value: 'Reject',
   domain: 'test.assessmystudy.nihr.ac.uk',
   path: '/',
-  expires: Math.floor(new Date('2028-10-17T09:09:17.000Z').getTime() / 1000),
+  expires: Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60, // sets one year from today
   httpOnly: false,
   secure: true,
+  sameSite: undefined
 }
 
 setup(
   'Authenticate the Sponsor Contact User',
   async ({ commonItemsPage, signedOutPage, loginPage, studiesPage, page }) => {
+    await page.context().addCookies([cookieConfig])
     await commonItemsPage.goto()
     await signedOutPage.assertOnSignedOutPage()
     await signedOutPage.btnSignIn.click()
     await loginPage.assertOnLoginPage()
     await loginPage.loginWithUserCreds('Sponsor Contact')
     await studiesPage.assertOnStudiesPage()
-    await page.context().addCookies([cookieConfig])
     await page.context().storageState({ path: authSponsorContactFile })
   }
 )
@@ -30,23 +33,28 @@ setup(
 setup(
   'Authenticate the Contact Manager User',
   async ({ commonItemsPage, signedOutPage, loginPage, organisationsPage, page }) => {
+    await page.context().addCookies([cookieConfig])
     await commonItemsPage.goto()
     await signedOutPage.assertOnSignedOutPage()
     await signedOutPage.btnSignIn.click()
     await loginPage.assertOnLoginPage()
     await loginPage.loginWithUserCreds('Contact Manager')
     await organisationsPage.assertOnOrganisationsPage()
-    await page.context().addCookies([cookieConfig])
     await page.context().storageState({ path: authContactManagerFile })
   }
 )
 
 setup('Authenticate the CPMS NPM User', async ({ cpmsStudiesPage, loginPage, page }) => {
+  await page.context().addCookies([cookieConfig])
   await cpmsStudiesPage.goToCpmsStudies()
   await cpmsStudiesPage.assertOnSignInPage()
   await cpmsStudiesPage.btnNext.click()
   await loginPage.loginWithUserCreds('National Portfolio Manager')
   await cpmsStudiesPage.assertOnCpmsStudiesPage()
-  await page.context().addCookies([cookieConfig])
   await page.context().storageState({ path: authNpmFile })
 })
+
+setup('Create a SEConsentGDPR cookie context without auth', async ({ page }) => {
+  await page.context().addCookies([cookieConfig])
+  await page.context().storageState({ path: cookieOnlyFile })
+}) // used for tests the don't require authentication

--- a/packages/qa/tests/features/accessibilityTests/axeAccessibilityTests.e2e.ts
+++ b/packages/qa/tests/features/accessibilityTests/axeAccessibilityTests.e2e.ts
@@ -268,6 +268,8 @@ test.describe('Organisation Accessibility Tests - @accessibility @accessibility_
 })
 
 test.describe('Landing Page Accessibility Tests - @accessibility @accessibility_landing', () => {
+  test.use({ storageState: '.auth/consentCookie.json' })
+
   test('Scan Create Password Page with AXE Tool @access_createPassword', async ({
     createPasswordPage,
     makeAxeBuilder,

--- a/packages/qa/utils/dbConfig.ts
+++ b/packages/qa/utils/dbConfig.ts
@@ -26,9 +26,9 @@ const sePassword =
 
 // cpms env variables and checks
 const cpmsServer =
-  process.env.CPMS_TEST_DB_IP ||
+  process.env.CPMS_TEST_DB_HOST ||
   (() => {
-    throw new Error('CPMS_TEST_DB_IP is not defined')
+    throw new Error('CPMS_TEST_DB_HOST is not defined')
   })()
 
 const cpmsUsername =


### PR DESCRIPTION
- updates use of `CPMS_TEST_DB_IP` to `CPMS_TEST_DB_HOST`
- removes node options for deprecation note
- removes internal dev language from readme and examples
- updates gdpr cookie method 