### PR TITLE
SE-253: Create dueAsssessmentAt field and replace existing logic

### DIFF
--- a/apps/ingest/README.md
+++ b/apps/ingest/README.md
@@ -39,4 +39,4 @@ The task is configured to run daily via a cron schedule defined in the `sponsor-
 
 ## Info
 
-The ingest task queries the CPMS API and processes studies iteratively in batches of 250. The task also handles soft deletion of studies and their relationships. (Note: organisations are not deleted because it was desired to keep them visible in the application for Contact Managers). During ingestion the `isDueAssessment` flag is set for studies that meet the criteria for being due assessment.
+The ingest task queries the CPMS API and processes studies iteratively in batches of 250. The task also handles soft deletion of studies and their relationships. (Note: organisations are not deleted because it was desired to keep them visible in the application for Contact Managers). During ingestion the `dueAssessmentAt` date field is set to the current date for studies that meet the criteria for being due assessment and do not already have this field set.

--- a/apps/ingest/src/ingest.ts
+++ b/apps/ingest/src/ingest.ts
@@ -12,22 +12,6 @@ import type { Study, StudySponsor, StudyWithRelationships } from './types'
 import { StudyRecordStatus, StudyStatus } from './types'
 import { getOrganisationName, getOrgsUniqueByName, getOrgsUniqueByNameRole, getOrgsUniqueByRole } from './utils'
 
-// If assessment is due:
-// - if there is already a date, leave as is.
-// - if there is not already a date, set to today's date
-
-// if assessment is not due:
-// - set to null
-
-// Problem:
-// we set all studies to not due and do not know the value of the assessemnt due date
-
-// Solutions?
-// 1
-// get the due date value or do not update it (i.e. retain value), set assessments to null currently instead leave value as is. this doesn't set new assessments to today's date. or do we run both?
-// if we run both, set assessment to null and set assessment to todays date (only if there isn't already a date)
-// assuming that an assessment will go to not due and then to due, in order for the date to update
-
 dotEnvConfig()
 
 // Entities related to the current batch of studies
@@ -65,13 +49,12 @@ const createStudies = async () => {
       actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
       actualClosureDate: study.ActualClosureDate ? new Date(study.ActualClosureDate) : null,
       estimatedReopeningDate: study.EstimatedReopeningDate ? new Date(study.EstimatedReopeningDate) : null,
-      isDueAssessment: false,
       isDeleted: false,
     }
 
     return prismaClient.study.upsert({
       where: { cpmsId: study.Id },
-      create: { ...studyData, dueAssessmentAt: null },
+      create: studyData,
       update: studyData,
       include: {
         organisations: {
@@ -449,7 +432,6 @@ export const ingest = async () => {
     const ids = studyEntities.map((study) => study.id)
     await setStudyAssessmentDue(ids)
     await setStudyAssessmentNotDue(ids)
-    // Set assessments to not due ? For new studies, this will be correct. For studies that are no longer due, we need to make sure we've set it to null.
   }
 
   await deleteStudies()

--- a/apps/ingest/src/tests/index.spec.ts
+++ b/apps/ingest/src/tests/index.spec.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { logger } from '@nihr-ui/logger'
-import { setStudyAssessmentDue } from 'shared-utilities'
+import { setStudyAssessmentDue, setStudyAssessmentNotDue } from 'shared-utilities'
 import { ingest } from '../ingest'
 import {
   organisationEntities,
@@ -33,6 +33,7 @@ interface EvalCategory {
 jest.mock('@nihr-ui/logger')
 jest.mock('shared-utilities')
 const mockSetStudyAssessmentDue = setStudyAssessmentDue as jest.MockedFunction<typeof setStudyAssessmentDue>
+const mockSetStudyAssessmentNotDue = setStudyAssessmentNotDue as jest.MockedFunction<typeof setStudyAssessmentNotDue>
 
 const API_URL = 'https://dev.cpmsapi.nihr.ac.uk/api/v1/study-summaries'
 
@@ -68,6 +69,7 @@ beforeEach(() => {
   prismaMock.studyFunder.createMany.mockResolvedValueOnce({ count: 1 })
   prismaMock.studyEvaluationCategory.updateMany.mockResolvedValueOnce({ count: 1 })
   mockSetStudyAssessmentDue.mockResolvedValueOnce({ count: 1 })
+  mockSetStudyAssessmentNotDue.mockResolvedValueOnce({ count: 1 })
 
   prismaMock.study.findMany.mockResolvedValueOnce(studyEntities)
   prismaMock.organisation.findMany.mockResolvedValueOnce(organisationEntities)
@@ -245,11 +247,14 @@ describe('ingest', () => {
     })
   })
 
-  it('should update the study `isDueAssessment` flag', async () => {
+  it('should update the study `dueAssessmentAt` flag', async () => {
     await ingest()
 
     expect(mockSetStudyAssessmentDue).toHaveBeenCalledTimes(1)
     expect(mockSetStudyAssessmentDue).toHaveBeenCalledWith(studyEntities.map(({ id }) => id))
+
+    expect(mockSetStudyAssessmentNotDue).toHaveBeenCalledTimes(1)
+    expect(mockSetStudyAssessmentNotDue).toHaveBeenCalledWith(studyEntities.map(({ id }) => id))
   })
 
   it('should handle errors when fetching studies', async () => {

--- a/apps/ingest/src/tests/index.spec.ts
+++ b/apps/ingest/src/tests/index.spec.ts
@@ -247,7 +247,7 @@ describe('ingest', () => {
     })
   })
 
-  it('should update the study `dueAssessmentAt` flag', async () => {
+  it('should make the correct requests to update the study `dueAssessmentAt` field', async () => {
     await ingest()
 
     expect(mockSetStudyAssessmentDue).toHaveBeenCalledTimes(1)

--- a/apps/notify/src/notify.ts
+++ b/apps/notify/src/notify.ts
@@ -35,7 +35,7 @@ const sendNotifications = async () => {
         organisations: {
           some: {
             organisation: {
-              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              studies: { some: { study: { dueAssessmentAt: { not: null }, isDeleted: false }, isDeleted: false } },
               isDeleted: false,
             },
             isDeleted: false,
@@ -52,7 +52,7 @@ const sendNotifications = async () => {
         organisations: {
           where: {
             organisation: {
-              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              studies: { some: { study: { dueAssessmentAt: { not: null }, isDeleted: false }, isDeleted: false } },
               isDeleted: false,
             },
             isDeleted: false,
@@ -73,7 +73,7 @@ const sendNotifications = async () => {
         organisations: {
           some: {
             organisation: {
-              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              studies: { some: { study: { dueAssessmentAt: { not: null }, isDeleted: false }, isDeleted: false } },
               isDeleted: false,
             },
             isDeleted: false,
@@ -90,7 +90,7 @@ const sendNotifications = async () => {
         organisations: {
           where: {
             organisation: {
-              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              studies: { some: { study: { dueAssessmentAt: { not: null }, isDeleted: false }, isDeleted: false } },
               isDeleted: false,
             },
             isDeleted: false,

--- a/apps/notify/src/tests/notify.spec.ts
+++ b/apps/notify/src/tests/notify.spec.ts
@@ -119,7 +119,7 @@ describe('notify', () => {
         organisations: {
           where: {
             organisation: {
-              studies: { some: { study: { isDueAssessment: true, isDeleted: false }, isDeleted: false } },
+              studies: { some: { study: { dueAssessmentAt: { not: null }, isDeleted: false }, isDeleted: false } },
               isDeleted: false,
             },
             isDeleted: false,

--- a/apps/web/src/__tests__/Assessment.spec.tsx
+++ b/apps/web/src/__tests__/Assessment.spec.tsx
@@ -50,7 +50,6 @@ const study = Mock.of<StudyWithRelations>({
   id: mockedStudyId,
   title: 'Test Study',
   cpmsId: 12345,
-  isDueAssessment: true,
   createdAt: new Date('2001-01-01'),
   managingSpeciality: 'Cancer',
   organisations: [

--- a/apps/web/src/__tests__/EditStudy.spec.tsx
+++ b/apps/web/src/__tests__/EditStudy.spec.tsx
@@ -108,7 +108,7 @@ describe('EditStudy', () => {
   })
 
   describe('getServerSideProps', () => {
-    const fixedDate = new Date('2025-03-20T12:00:00Z')
+    const mockDate = new Date('2025-03-20T12:00:00Z')
 
     test('redirects to 404 page if no study found', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {}, query: mockQuery })
@@ -280,7 +280,7 @@ describe('EditStudy', () => {
 
     test('when study is due for assessment, should return study with the correct date', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {}, query: mockQuery })
-      jest.useFakeTimers().setSystemTime(fixedDate)
+      jest.useFakeTimers().setSystemTime(mockDate)
 
       getServerSessionMock.mockResolvedValueOnce(userWithSponsorContactRole)
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
@@ -299,7 +299,7 @@ describe('EditStudy', () => {
             ...mockStudyWithRelations,
             evaluationCategories: mappedCPMSStudyEvals,
             organisationsByRole,
-            dueAssessmentAt: fixedDate,
+            dueAssessmentAt: mockDate,
           },
           currentLSN: mockLSN,
           query: mockQuery,

--- a/apps/web/src/__tests__/Studies.spec.tsx
+++ b/apps/web/src/__tests__/Studies.spec.tsx
@@ -58,6 +58,7 @@ describe('getServerSideProps', () => {
 const mockStudies = Array.from(Array(15)).map((_, index) => ({
   id: index === 0 ? 'mocked-id' : simpleFaker.number.int(),
   shortTitle: 'Test Study',
+  isDueAssessment: index === 0,
   dueAssessmentAt: index === 0 ? new Date('2001-01-01') : null,
   organisations: [
     {

--- a/apps/web/src/__tests__/Studies.spec.tsx
+++ b/apps/web/src/__tests__/Studies.spec.tsx
@@ -58,7 +58,7 @@ describe('getServerSideProps', () => {
 const mockStudies = Array.from(Array(15)).map((_, index) => ({
   id: index === 0 ? 'mocked-id' : simpleFaker.number.int(),
   shortTitle: 'Test Study',
-  isDueAssessment: index === 0,
+  dueAssessmentAt: index === 0 ? new Date('2001-01-01') : null,
   organisations: [
     {
       organisation: {

--- a/apps/web/src/__tests__/Study.spec.tsx
+++ b/apps/web/src/__tests__/Study.spec.tsx
@@ -6,7 +6,7 @@ import type { GetServerSidePropsContext } from 'next'
 import { getServerSession } from 'next-auth/next'
 import mockRouter from 'next-router-mock'
 import { NextSeo } from 'next-seo'
-import { setStudyAssessmentDue } from 'shared-utilities'
+import { setStudyAssessmentDue, setStudyAssessmentNotDue } from 'shared-utilities'
 import { Mock } from 'ts-mockery'
 
 import { render, screen, within } from '@/config/TestUtils'
@@ -32,7 +32,8 @@ jest.mock('axios')
 jest.mock('shared-utilities')
 
 const mockedGetAxios = jest.mocked(axios.get)
-const mockSetStudyAssessmentDue = setStudyAssessmentDue as jest.MockedFunction<typeof setStudyAssessmentDue>
+const mockSetStudyAssessmentDueDate = setStudyAssessmentDue as jest.MockedFunction<typeof setStudyAssessmentDue>
+const mockSetStudyAssessmentNotDue = setStudyAssessmentNotDue as jest.MockedFunction<typeof setStudyAssessmentNotDue>
 
 const env = { ...process.env }
 const mockedEnvVars = {
@@ -100,7 +101,9 @@ const renderPage = async (
   prismaMock.$transaction.mockResolvedValueOnce([mockGetStudyResponse])
   mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockGetCPMSStudyResponse } })
   prismaMock.study.update.mockResolvedValueOnce(mockUpdateStudyResponse)
-  mockSetStudyAssessmentDue.mockResolvedValueOnce({ count: isAssessmentDue ? 1 : 0 })
+  mockSetStudyAssessmentDueDate.mockResolvedValueOnce({ count: isAssessmentDue ? 1 : 0 })
+  mockSetStudyAssessmentNotDue.mockResolvedValueOnce({ count: isAssessmentDue ? 0 : 1 })
+
   mockUpdatedStudyEvals.forEach((studyEval) =>
     prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(studyEval)
   )
@@ -147,6 +150,8 @@ describe('Study', () => {
   })
 
   describe('getServerSideProps', () => {
+    const fixedDate = new Date('2025-03-20T12:00:00Z')
+
     const getServerSessionMock = jest.mocked(getServerSession)
     test('redirects to sign in page when there is no user session', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {} })
@@ -202,7 +207,8 @@ describe('Study', () => {
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
       mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockCPMSStudy } })
       prismaMock.study.update.mockResolvedValueOnce(mockStudyWithRelations)
-      mockSetStudyAssessmentDue.mockResolvedValueOnce({ count: 0 })
+      mockSetStudyAssessmentDueDate.mockResolvedValueOnce({ count: 0 })
+      mockSetStudyAssessmentNotDue.mockResolvedValueOnce({ count: 0 })
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[0])
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[1])
       prismaMock.studyUpdates.groupBy.mockResolvedValueOnce([])
@@ -284,7 +290,8 @@ describe('Study', () => {
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
       mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockCPMSStudy } })
       prismaMock.study.update.mockResolvedValueOnce(mockStudyWithRelations)
-      mockSetStudyAssessmentDue.mockResolvedValueOnce({ count: 0 })
+      mockSetStudyAssessmentDueDate.mockResolvedValueOnce({ count: 0 })
+      mockSetStudyAssessmentNotDue.mockResolvedValueOnce({ count: 0 })
       prismaMock.studyEvaluationCategory.upsert.mockRejectedValueOnce(new Error('Oh no, an error!'))
       prismaMock.studyUpdates.groupBy.mockResolvedValueOnce([])
       prismaMock.studyUpdates.findMany.mockResolvedValueOnce([])
@@ -310,13 +317,13 @@ describe('Study', () => {
       expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(2)
     })
 
-    test('when request to set study assessment flag fails, it should not throw a 500 and return correct study', async () => {
+    test('when request to update if an assessment is due fails, it should not throw a 500 and return correct study', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {}, query: { studyId: mockStudyId } })
       getServerSessionMock.mockResolvedValueOnce(userWithSponsorContactRole)
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
       mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockCPMSStudy } })
       prismaMock.study.update.mockResolvedValueOnce(mockStudyWithRelations)
-      mockSetStudyAssessmentDue.mockRejectedValueOnce({})
+      mockSetStudyAssessmentNotDue.mockRejectedValueOnce({})
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[0])
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[1])
       prismaMock.studyUpdates.groupBy.mockResolvedValueOnce([])
@@ -339,18 +346,20 @@ describe('Study', () => {
 
       expect(prismaMock.$transaction).toHaveBeenCalledTimes(1)
       expect(prismaMock.study.update).toHaveBeenCalledTimes(1)
-      expect(mockSetStudyAssessmentDue).toHaveBeenCalledTimes(1)
+      expect(mockSetStudyAssessmentNotDue).toHaveBeenCalledTimes(1)
       expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(2)
       expect(mockedGetAxios).toHaveBeenCalledTimes(1)
     })
 
-    test('when study is due for assessment, should return study with the correct flag', async () => {
+    test('when study is due for assessment, should return study with the correct date', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {}, query: { studyId: mockStudyId } })
+      jest.useFakeTimers().setSystemTime(fixedDate)
       getServerSessionMock.mockResolvedValueOnce(userWithSponsorContactRole)
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
       mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockCPMSStudy } })
       prismaMock.study.update.mockResolvedValueOnce(mockStudyWithRelations)
-      mockSetStudyAssessmentDue.mockResolvedValueOnce({ count: 1 })
+      mockSetStudyAssessmentDueDate.mockResolvedValueOnce({ count: 1 })
+      mockSetStudyAssessmentNotDue.mockResolvedValueOnce({ count: 0 })
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[0])
       prismaMock.studyEvaluationCategory.upsert.mockResolvedValueOnce(mappedCPMSStudyEvals[1])
       prismaMock.studyUpdates.groupBy.mockResolvedValueOnce([])
@@ -366,7 +375,7 @@ describe('Study', () => {
             ...mockStudyWithRelations,
             evaluationCategories: mappedCPMSStudyEvals,
             organisationsByRole,
-            isDueAssessment: true,
+            dueAssessmentAt: fixedDate,
           },
           editHistory: getMockEditHistoryFromCPMS([false, false]),
         },
@@ -376,6 +385,7 @@ describe('Study', () => {
       expect(prismaMock.study.update).toHaveBeenCalledTimes(1)
       expect(prismaMock.studyEvaluationCategory.upsert).toHaveBeenCalledTimes(2)
       expect(mockedGetAxios).toHaveBeenCalledTimes(1)
+      jest.useRealTimers()
     })
   })
 

--- a/apps/web/src/__tests__/Study.spec.tsx
+++ b/apps/web/src/__tests__/Study.spec.tsx
@@ -150,7 +150,7 @@ describe('Study', () => {
   })
 
   describe('getServerSideProps', () => {
-    const fixedDate = new Date('2025-03-20T12:00:00Z')
+    const mockDate = new Date('2025-03-20T12:00:00Z')
 
     const getServerSessionMock = jest.mocked(getServerSession)
     test('redirects to sign in page when there is no user session', async () => {
@@ -353,7 +353,7 @@ describe('Study', () => {
 
     test('when study is due for assessment, should return study with the correct date', async () => {
       const context = Mock.of<GetServerSidePropsContext>({ req: {}, res: {}, query: { studyId: mockStudyId } })
-      jest.useFakeTimers().setSystemTime(fixedDate)
+      jest.useFakeTimers().setSystemTime(mockDate)
       getServerSessionMock.mockResolvedValueOnce(userWithSponsorContactRole)
       prismaMock.$transaction.mockResolvedValueOnce([mockStudyWithRelations])
       mockedGetAxios.mockResolvedValueOnce({ data: { StatusCode: 200, Result: mockCPMSStudy } })
@@ -375,7 +375,7 @@ describe('Study', () => {
             ...mockStudyWithRelations,
             evaluationCategories: mappedCPMSStudyEvals,
             organisationsByRole,
-            dueAssessmentAt: fixedDate,
+            dueAssessmentAt: mockDate,
           },
           editHistory: getMockEditHistoryFromCPMS([false, false]),
         },

--- a/apps/web/src/config/jest/jest.setup.js
+++ b/apps/web/src/config/jest/jest.setup.js
@@ -13,3 +13,7 @@ global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder
 
 global.structuredClone = (v) => JSON.parse(JSON.stringify(v))
+
+Object.defineProperty(window, 'scrollTo', {
+  value: jest.fn(),
+})

--- a/apps/web/src/lib/studies.spec.ts
+++ b/apps/web/src/lib/studies.spec.ts
@@ -329,7 +329,6 @@ describe('updateStudy', () => {
     id: studyId,
     title: mockStudyInputs.title as string,
     cpmsId: mockStudyInputs.cpmsId as number,
-    isDueAssessment: true,
     createdAt: new Date('2001-01-01'),
     managingSpeciality: 'Cancer',
     organisations: [

--- a/apps/web/src/lib/studies.spec.ts
+++ b/apps/web/src/lib/studies.spec.ts
@@ -593,7 +593,6 @@ describe('mapCPMSStudyToSEStudy', () => {
     actualOpeningDate: new Date(mockCPMSStudy.ActualOpeningDate as string),
     actualClosureDate: new Date(mockCPMSStudy.ActualClosureToRecruitmentDate as string),
     estimatedReopeningDate: new Date(mockCPMSStudy.EstimatedReopeningDate as string),
-    isDueAssessment: false,
   }
 
   it('correctly maps data when all fields exist', () => {

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -184,6 +184,7 @@ export const getStudiesForOrgs = async ({
       title: true,
       shortTitle: true,
       isDueAssessment: true,
+      dueAssessmentAt: true,
       lastAssessment: {
         include: {
           status: true,

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -342,7 +342,6 @@ export const mapCPMSStudyToSEStudy = (study: Study): UpdateStudyInput => ({
   actualOpeningDate: study.ActualOpeningDate ? new Date(study.ActualOpeningDate) : null,
   actualClosureDate: study.ActualClosureToRecruitmentDate ? new Date(study.ActualClosureToRecruitmentDate) : null,
   estimatedReopeningDate: study.EstimatedReopeningDate ? new Date(study.EstimatedReopeningDate) : null,
-  isDueAssessment: false,
 })
 
 export const updateStudy = async (cpmsId: number, studyData: UpdateStudyInput) => {

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -1,5 +1,5 @@
 import { logger } from '@nihr-ui/logger'
-import { setStudyAssessmentDue } from 'shared-utilities'
+import { setStudyAssessmentDue, setStudyAssessmentNotDue as setStudyAssessmentNotDueUtil } from 'shared-utilities'
 
 import type { Study, StudyEvaluationCategory } from '@/@types/studies'
 import { Status as CPMSStatus } from '@/@types/studies'
@@ -183,7 +183,7 @@ export const getStudiesForOrgs = async ({
       id: true,
       title: true,
       shortTitle: true,
-      isDueAssessment: true,
+      dueAssessmentAt: true,
       lastAssessment: {
         include: {
           status: true,
@@ -213,7 +213,9 @@ export const getStudiesForOrgs = async ({
     prismaClient.study.count({
       where: {
         ...query.where,
-        isDueAssessment: true,
+        dueAssessmentAt: {
+          not: null,
+        },
       },
     }),
   ])
@@ -454,18 +456,41 @@ export const updateEvaluationCategories = async (
   }
 }
 
-export const setStudyAssessmentDueFlag = async (studyIds: number[]) => {
+export const setStudyAssessmentDueDate = async (studyIds: number[]) => {
   try {
     const assessmentDueResult = await setStudyAssessmentDue(studyIds)
 
-    logger.info('Successfully set assessment due for studys with Ids: %s', JSON.stringify(studyIds))
+    logger.info('Successfully checked if assessment is due for studys with Ids: %s', JSON.stringify(studyIds))
 
     return { data: assessmentDueResult.count }
   } catch (error) {
     const errorMessage = getErrorMessage(error)
 
     logger.error(
-      'Failed to set study assessment due flag for studys with Ids: %s, error: %s',
+      'Failed to set study assessment due date for studys with Ids: %s, error: %s',
+      JSON.stringify(studyIds),
+      errorMessage
+    )
+
+    return {
+      data: null,
+      error: errorMessage,
+    }
+  }
+}
+
+export const setStudyAssessmentNotDue = async (studyIds: number[]) => {
+  try {
+    const assessmentNotDueResult = await setStudyAssessmentNotDueUtil(studyIds)
+
+    logger.info('Successfully checked if assessment is not due for studys with Ids: %s', JSON.stringify(studyIds))
+
+    return { data: assessmentNotDueResult.count }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+
+    logger.error(
+      'Failed to set study assessment as not due for studys with Ids: %s, error: %s',
       JSON.stringify(studyIds),
       errorMessage
     )

--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -183,7 +183,7 @@ export const getStudiesForOrgs = async ({
       id: true,
       title: true,
       shortTitle: true,
-      dueAssessmentAt: true,
+      isDueAssessment: true,
       lastAssessment: {
         include: {
           status: true,
@@ -213,9 +213,7 @@ export const getStudiesForOrgs = async ({
     prismaClient.study.count({
       where: {
         ...query.where,
-        dueAssessmentAt: {
-          not: null,
-        },
+        isDueAssessment: true,
       },
     }),
   ])

--- a/apps/web/src/mocks/studies.ts
+++ b/apps/web/src/mocks/studies.ts
@@ -31,6 +31,7 @@ export const mockStudiesForExport = Array.from({ length: 3 }).map((_, index) =>
     sampleSize: simpleFaker.number.int(),
     totalRecruitmentToDate: simpleFaker.number.int(),
     isDueAssessment: index === 0,
+    dueAssessmentAt: index === 0 ? new Date('2001-01-01') : null,
     organisations: [
       {
         organisation: {
@@ -266,7 +267,7 @@ export const mockStudyWithRelations = Mock.of<StudyWithRelations>({
   id: 123,
   title: 'Test Study Long Title',
   shortTitle: 'Test Study Short Title',
-  isDueAssessment: false,
+  dueAssessmentAt: new Date('2003-01-02'),
   cpmsId: 1234567,
   studyStatus: 'Suspended',
   recordStatus: 'Test record status',

--- a/apps/web/src/pages/api/export.ts
+++ b/apps/web/src/pages/api/export.ts
@@ -57,7 +57,7 @@ const studyDataMappers: Partial<Record<ColumnKeys, StudyDataMapper>> = {
   sponsorOrg: (study) => getSponsorOrgName(study.organisations),
   studyCRO: (study) => (study.route === 'Commercial' ? getSupportOrgName(study.organisations) : undefined),
   studyCTU: (study) => (study.route !== 'Commercial' ? getSupportOrgName(study.organisations) : undefined),
-  isDueAssessment: (study) => (study.isDueAssessment ? 'Yes' : 'No'),
+  isDueAssessment: (study) => (study.dueAssessmentAt ? 'Yes' : 'No'),
   lastAssessmentStatus: (study) => study.lastAssessment?.status.name,
   lastAssessmentDate: (study) => study.lastAssessment?.createdAt,
   lastAssessmentInfo: (study) =>

--- a/apps/web/src/pages/api/forms/assessment.spec.ts
+++ b/apps/web/src/pages/api/forms/assessment.spec.ts
@@ -84,7 +84,7 @@ describe('Successful study assessment submission', () => {
     // Study is updated to not be due an assessment
     expect(updateStudyMock).toHaveBeenCalledWith({
       where: { id: 999 },
-      data: { dueAssessmentAt: null, isDueAssessment: false, lastAssessmentId: 1 },
+      data: { dueAssessmentAt: null, lastAssessmentId: 1 },
     })
 
     expect(logger.info).toHaveBeenCalledWith('Added assessment with id: 1')
@@ -130,7 +130,7 @@ describe('Successful study assessment submission', () => {
     // Study is updated to not be due an assessment
     expect(updateStudyMock).toHaveBeenCalledWith({
       where: { id: 999 },
-      data: { dueAssessmentAt: null, isDueAssessment: false, lastAssessmentId: 1 },
+      data: { dueAssessmentAt: null, lastAssessmentId: 1 },
     })
 
     expect(logger.info).toHaveBeenCalledWith('Added assessment with id: 1')

--- a/apps/web/src/pages/api/forms/assessment.spec.ts
+++ b/apps/web/src/pages/api/forms/assessment.spec.ts
@@ -84,7 +84,7 @@ describe('Successful study assessment submission', () => {
     // Study is updated to not be due an assessment
     expect(updateStudyMock).toHaveBeenCalledWith({
       where: { id: 999 },
-      data: { isDueAssessment: false, lastAssessmentId: 1 },
+      data: { dueAssessmentAt: null, isDueAssessment: false, lastAssessmentId: 1 },
     })
 
     expect(logger.info).toHaveBeenCalledWith('Added assessment with id: 1')
@@ -130,7 +130,7 @@ describe('Successful study assessment submission', () => {
     // Study is updated to not be due an assessment
     expect(updateStudyMock).toHaveBeenCalledWith({
       where: { id: 999 },
-      data: { isDueAssessment: false, lastAssessmentId: 1 },
+      data: { dueAssessmentAt: null, isDueAssessment: false, lastAssessmentId: 1 },
     })
 
     expect(logger.info).toHaveBeenCalledWith('Added assessment with id: 1')

--- a/apps/web/src/pages/api/forms/assessment.ts
+++ b/apps/web/src/pages/api/forms/assessment.ts
@@ -60,6 +60,7 @@ export default withApiHandler<ExtendedNextApiRequest>([Roles.SponsorContact], as
       },
       data: {
         isDueAssessment: false,
+        dueAssessmentAt: null,
         lastAssessmentId: assessmentResult.id,
       },
     })

--- a/apps/web/src/pages/api/forms/assessment.ts
+++ b/apps/web/src/pages/api/forms/assessment.ts
@@ -59,7 +59,6 @@ export default withApiHandler<ExtendedNextApiRequest>([Roles.SponsorContact], as
         id: Number(studyId),
       },
       data: {
-        isDueAssessment: false,
         dueAssessmentAt: null,
         lastAssessmentId: assessmentResult.id,
       },

--- a/apps/web/src/pages/studies/[studyId]/edit.tsx
+++ b/apps/web/src/pages/studies/[studyId]/edit.tsx
@@ -35,7 +35,6 @@ import {
   mapCPMSStudyEvalToSEEval,
   mapCPMSStudyToSEStudy,
   mapFormStatusToCPMSStatus,
-  setStudyAssessmentDueDate,
   updateEvaluationCategories,
   updateStudy,
 } from '@/lib/studies'
@@ -481,13 +480,8 @@ export const getServerSideProps = withServerSideProps([Roles.SponsorContact], as
       },
     }
   }
-
-  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueDate([study.id])
-  console.log('current due value', { setStudyAssessmentDueResponse, currentDueAssessmentAt })
-
   const dueAssessmentAt = await getStudyAssessmentDueDate(study.id, currentDueAssessmentAt)
 
-  console.log('new date to be set', { dueAssessmentAt })
   const currentStudyEvalsInSE = updatedStudy.evaluationCategories
 
   // Soft delete evaluations in SE that are no longer returned from CPMS

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -91,7 +91,7 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
           </span>
 
           <div className="flex flex-col govuk-!-margin-bottom-4 govuk-!-margin-top-4 gap-6">
-            {Boolean(study.isDueAssessment) && (
+            {Boolean(study.dueAssessmentAt) && (
               <div>
                 <span className="govuk-tag govuk-tag--red mr-2">Due</span>
                 This study needs a new sponsor assessment.

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -26,11 +26,11 @@ import {
   mapCPMSStatusToFormStatus,
   mapCPMSStudyEvalToSEEval,
   mapCPMSStudyToSEStudy,
-  setStudyAssessmentDueFlag,
   updateEvaluationCategories,
   updateStudy,
 } from '@/lib/studies'
 import { formatDate } from '@/utils/date'
+import { getStudyAssessmentDueDate } from '@/utils/studies'
 import { withServerSideProps } from '@/utils/withServerSideProps'
 
 const renderNotificationBanner = (success: string | undefined, showRequestSupportLink: boolean) =>
@@ -263,8 +263,8 @@ export const getServerSideProps = withServerSideProps([Roles.SponsorContact], as
     }
   }
 
-  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueFlag([studyId])
-  const isStudyDueAssessment = setStudyAssessmentDueResponse !== null ? setStudyAssessmentDueResponse === 1 : false
+  const currentDueAssessmentAt = study.dueAssessmentAt
+  const dueAssessmentAt = await getStudyAssessmentDueDate(study.id, currentDueAssessmentAt)
 
   const currentStudyEvalsInSE = updatedStudy.evaluationCategories
 
@@ -291,7 +291,7 @@ export const getServerSideProps = withServerSideProps([Roles.SponsorContact], as
       study: {
         ...updatedStudy,
         evaluationCategories: updatedStudyEvals ?? study.evaluationCategories,
-        isDueAssessment: isStudyDueAssessment,
+        dueAssessmentAt,
       },
       editHistory,
       getEditHistoryError,

--- a/apps/web/src/pages/studies/index.tsx
+++ b/apps/web/src/pages/studies/index.tsx
@@ -133,7 +133,7 @@ export default function Studies({
                     {studies.map((study) => (
                       <li key={study.id}>
                         <StudyList
-                          assessmentDue={Boolean(study.isDueAssessment)}
+                          assessmentDue={Boolean(study.dueAssessmentAt)}
                           indications={study.evaluationCategories
                             .map((evalCategory) => evalCategory.indicatorType)
                             .filter((evalCategory, index, items) => items.indexOf(evalCategory) === index)}

--- a/apps/web/src/pages/studies/index.tsx
+++ b/apps/web/src/pages/studies/index.tsx
@@ -133,7 +133,7 @@ export default function Studies({
                     {studies.map((study) => (
                       <li key={study.id}>
                         <StudyList
-                          assessmentDue={Boolean(study.dueAssessmentAt)}
+                          assessmentDue={Boolean(study.isDueAssessment)}
                           indications={study.evaluationCategories
                             .map((evalCategory) => evalCategory.indicatorType)
                             .filter((evalCategory, index, items) => items.indexOf(evalCategory) === index)}

--- a/apps/web/src/utils/studies.spec.ts
+++ b/apps/web/src/utils/studies.spec.ts
@@ -1,0 +1,78 @@
+import { setStudyAssessmentDueDate, setStudyAssessmentNotDue } from '@/lib/studies'
+
+import { getStudyAssessmentDueDate } from './studies'
+
+jest.mock('../lib/studies')
+
+const mockSetStudyAssessmentNotDue = setStudyAssessmentNotDue as jest.MockedFunction<typeof setStudyAssessmentNotDue>
+const mockSetStudyAssessmentDueDate = setStudyAssessmentDueDate as jest.MockedFunction<typeof setStudyAssessmentDueDate>
+
+describe('getStudyAssessmentDueDate', () => {
+  const studyId = 1
+  const mockDate = new Date('2025-03-20T00:00:00.000Z')
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(mockDate)
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should return current assessment due date when there is an error checking if an assessment is not due', async () => {
+    mockSetStudyAssessmentNotDue.mockResolvedValue({ data: null, error: 'An error occurred' })
+    const currentAssessmentDueDate = new Date('2025-01-01T00:00:00.000Z')
+
+    const result = await getStudyAssessmentDueDate(studyId, currentAssessmentDueDate)
+
+    expect(result).toBe(currentAssessmentDueDate)
+    expect(setStudyAssessmentNotDue).toHaveBeenCalledWith([studyId])
+    expect(setStudyAssessmentDueDate).not.toHaveBeenCalled()
+  })
+
+  it('should return null when study is not due an assessment', async () => {
+    mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 1 })
+
+    const result = await getStudyAssessmentDueDate(studyId, null)
+
+    expect(result).toBeNull()
+    expect(setStudyAssessmentNotDue).toHaveBeenCalledWith([studyId])
+    expect(setStudyAssessmentDueDate).not.toHaveBeenCalled()
+  })
+
+  it('should return current assessment due date when there is an error checking if an assessment is due ', async () => {
+    mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 0 })
+    mockSetStudyAssessmentDueDate.mockResolvedValue({ data: null, error: 'An error occurred' })
+
+    const currentAssessmentDueDate = new Date('2025-01-01T00:00:00.000Z')
+    const result = await getStudyAssessmentDueDate(studyId, currentAssessmentDueDate)
+
+    expect(result).toBe(currentAssessmentDueDate)
+    expect(setStudyAssessmentNotDue).toHaveBeenCalledWith([studyId])
+    expect(setStudyAssessmentDueDate).toHaveBeenCalledWith([studyId])
+  })
+
+  it('should return current assessment due date when study is due an assessment and current date exists', async () => {
+    mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 0 })
+    mockSetStudyAssessmentDueDate.mockResolvedValue({ data: 0 })
+
+    const currentAssessmentDueDate = new Date('2025-01-01T00:00:00.000Z')
+    const result = await getStudyAssessmentDueDate(studyId, currentAssessmentDueDate)
+
+    expect(result).toBe(currentAssessmentDueDate)
+    expect(setStudyAssessmentNotDue).toHaveBeenCalledWith([studyId])
+    expect(setStudyAssessmentDueDate).toHaveBeenCalledWith([studyId])
+  })
+
+  it('should return a new date when an assessment is due for an assessment and no previous date exists', async () => {
+    mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 0 })
+    mockSetStudyAssessmentDueDate.mockResolvedValue({ data: 1 })
+
+    const result = await getStudyAssessmentDueDate(studyId, null)
+
+    expect(result).toEqual(mockDate)
+    expect(setStudyAssessmentNotDue).toHaveBeenCalledWith([studyId])
+    expect(setStudyAssessmentDueDate).toHaveBeenCalledWith([studyId])
+  })
+})

--- a/apps/web/src/utils/studies.spec.ts
+++ b/apps/web/src/utils/studies.spec.ts
@@ -7,7 +7,7 @@ jest.mock('../lib/studies')
 const mockSetStudyAssessmentNotDue = setStudyAssessmentNotDue as jest.MockedFunction<typeof setStudyAssessmentNotDue>
 const mockSetStudyAssessmentDueDate = setStudyAssessmentDueDate as jest.MockedFunction<typeof setStudyAssessmentDueDate>
 
-describe('getStudyAssessmentDueDate', () => {
+describe('getStudyAssessmentDueDate()', () => {
   const studyId = 1
   const mockDate = new Date('2025-03-20T00:00:00.000Z')
 
@@ -31,7 +31,7 @@ describe('getStudyAssessmentDueDate', () => {
     expect(setStudyAssessmentDueDate).not.toHaveBeenCalled()
   })
 
-  it('should return null when study is not due an assessment', async () => {
+  it('should return null when assessment is not due', async () => {
     mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 1 })
 
     const result = await getStudyAssessmentDueDate(studyId, null)
@@ -53,7 +53,7 @@ describe('getStudyAssessmentDueDate', () => {
     expect(setStudyAssessmentDueDate).toHaveBeenCalledWith([studyId])
   })
 
-  it('should return current assessment due date when study is due an assessment and current date exists', async () => {
+  it('should return current assessment due date when requests to set assessment as due and not due, does not make any updates and current date exists', async () => {
     mockSetStudyAssessmentNotDue.mockResolvedValue({ data: 0 })
     mockSetStudyAssessmentDueDate.mockResolvedValue({ data: 0 })
 

--- a/apps/web/src/utils/studies.ts
+++ b/apps/web/src/utils/studies.ts
@@ -1,26 +1,26 @@
 import { setStudyAssessmentDueDate, setStudyAssessmentNotDue } from '@/lib/studies'
 
 export const getStudyAssessmentDueDate = async (studyId: number, currentAssessmentDueDate: Date | null) => {
-  const { data: setStudyAssessmentNotDueResponse } = await setStudyAssessmentNotDue([studyId])
+  const { data: studyAssessmentNotDueResponse } = await setStudyAssessmentNotDue([studyId])
 
-  if (setStudyAssessmentNotDueResponse === null) {
+  if (studyAssessmentNotDueResponse === null) {
     return currentAssessmentDueDate
   }
 
-  if (setStudyAssessmentNotDueResponse !== 0) {
+  if (studyAssessmentNotDueResponse > 0) {
     // Not due for an assessment
     return null
   }
 
   // Assessment should be due for an assessment
-  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueDate([studyId])
+  const { data: studyAssessmentDueResponse } = await setStudyAssessmentDueDate([studyId])
 
-  if (setStudyAssessmentDueResponse === null) {
+  if (studyAssessmentDueResponse === null) {
     return currentAssessmentDueDate
   }
 
   // If there is already a date set, `setStudyAssessmentDueDate` will return 0 as no update was done.
-  if (setStudyAssessmentDueResponse === 0) {
+  if (studyAssessmentDueResponse === 0) {
     if (currentAssessmentDueDate) {
       return currentAssessmentDueDate
     }

--- a/apps/web/src/utils/studies.ts
+++ b/apps/web/src/utils/studies.ts
@@ -3,16 +3,21 @@ import { setStudyAssessmentDueDate, setStudyAssessmentNotDue } from '@/lib/studi
 export const getStudyAssessmentDueDate = async (studyId: number, currentAssessmentDueDate: Date | null) => {
   const { data: setStudyAssessmentNotDueResponse } = await setStudyAssessmentNotDue([studyId])
 
-  console.log('getStudyAssessmentDueDate', { setStudyAssessmentNotDueResponse })
+  if (setStudyAssessmentNotDueResponse === null) {
+    return currentAssessmentDueDate
+  }
+
   if (setStudyAssessmentNotDueResponse !== 0) {
     // Not due for an assessment
     return null
   }
 
-  // Assessment should now be due for an assessment
+  // Assessment should be due for an assessment
   const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueDate([studyId])
 
-  console.log('getStudyAssessmentDueDate', { setStudyAssessmentDueResponse })
+  if (setStudyAssessmentDueResponse === null) {
+    return currentAssessmentDueDate
+  }
 
   // If there is already a date set, `setStudyAssessmentDueDate` will return 0 as no update was done.
   if (setStudyAssessmentDueResponse === 0) {

--- a/apps/web/src/utils/studies.ts
+++ b/apps/web/src/utils/studies.ts
@@ -1,0 +1,25 @@
+import { setStudyAssessmentDueDate, setStudyAssessmentNotDue } from '@/lib/studies'
+
+export const getStudyAssessmentDueDate = async (studyId: number, currentAssessmentDueDate: Date | null) => {
+  const { data: setStudyAssessmentNotDueResponse } = await setStudyAssessmentNotDue([studyId])
+
+  console.log('getStudyAssessmentDueDate', { setStudyAssessmentNotDueResponse })
+  if (setStudyAssessmentNotDueResponse !== 0) {
+    // Not due for an assessment
+    return null
+  }
+
+  // Assessment should now be due for an assessment
+  const { data: setStudyAssessmentDueResponse } = await setStudyAssessmentDueDate([studyId])
+
+  console.log('getStudyAssessmentDueDate', { setStudyAssessmentDueResponse })
+
+  // If there is already a date set, `setStudyAssessmentDueDate` will return 0 as no update was done.
+  if (setStudyAssessmentDueResponse === 0) {
+    if (currentAssessmentDueDate) {
+      return currentAssessmentDueDate
+    }
+  }
+
+  return new Date()
+}

--- a/apps/web/src/utils/studies.ts
+++ b/apps/web/src/utils/studies.ts
@@ -20,10 +20,8 @@ export const getStudyAssessmentDueDate = async (studyId: number, currentAssessme
   }
 
   // If there is already a date set, `setStudyAssessmentDueDate` will return 0 as no update was done.
-  if (studyAssessmentDueResponse === 0) {
-    if (currentAssessmentDueDate) {
-      return currentAssessmentDueDate
-    }
+  if (studyAssessmentDueResponse === 0 && currentAssessmentDueDate) {
+    return currentAssessmentDueDate
   }
 
   return new Date()

--- a/packages/database/prisma/migrations/20250320112123_due_assessment_at/migration.sql
+++ b/packages/database/prisma/migrations/20250320112123_due_assessment_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Study` ADD COLUMN `dueAssessmentAt` DATETIME(3) NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Study {
   createdAt                  DateTime                  @default(now())
   updatedAt                  DateTime                  @updatedAt
   isDueAssessment            Boolean?                  @default(false)
+  dueAssessmentAt            DateTime?
   isDeleted                  Boolean?                  @default(false)
   StudyUpdates               StudyUpdates[]
 

--- a/packages/qa/pages/StudiesPage.ts
+++ b/packages/qa/pages/StudiesPage.ts
@@ -381,7 +381,7 @@ export default class StudiesPage {
   async assertListEndsWithNonDueStudies(sortedList: RowDataPacket[]) {
     function checkForStudyNotDue(studies: any) {
       for (let study of studies) {
-        if (Boolean(study.isDueAssessment)) {
+        if (study.isDueAssessment === 0) {
           console.log('At least 1 study is not due an assessment, checking last study status...')
           return true
         }

--- a/packages/qa/pages/StudiesPage.ts
+++ b/packages/qa/pages/StudiesPage.ts
@@ -381,7 +381,7 @@ export default class StudiesPage {
   async assertListEndsWithNonDueStudies(sortedList: RowDataPacket[]) {
     function checkForStudyNotDue(studies: any) {
       for (let study of studies) {
-        if (study.isDueAssessment === 0) {
+        if (Boolean(study.dueAssessmentAt)) {
           console.log('At least 1 study is not due an assessment, checking last study status...')
           return true
         }

--- a/packages/qa/pages/StudiesPage.ts
+++ b/packages/qa/pages/StudiesPage.ts
@@ -381,7 +381,7 @@ export default class StudiesPage {
   async assertListEndsWithNonDueStudies(sortedList: RowDataPacket[]) {
     function checkForStudyNotDue(studies: any) {
       for (let study of studies) {
-        if (Boolean(study.dueAssessmentAt)) {
+        if (Boolean(study.isDueAssessment)) {
           console.log('At least 1 study is not due an assessment, checking last study status...')
           return true
         }

--- a/packages/qa/tests/features/accessibilityTests/axeAccessibilityTests.e2e.ts
+++ b/packages/qa/tests/features/accessibilityTests/axeAccessibilityTests.e2e.ts
@@ -13,7 +13,7 @@ test.beforeAll('Setup Tests', async () => {
     INNER JOIN StudyOrganisation
     ON Study.id = StudyOrganisation.studyId
     WHERE StudyOrganisation.organisationId = ${startingOrgId} AND StudyOrganisation.isDeleted = 0 
-    AND Study.isDueAssessment = 1 AND Study.isDeleted = 0
+    AND Study.dueAssessmentAt IS NOT NULL AND Study.isDeleted = 0
     ORDER BY RAND() LIMIT 1;`)
   startingStudyId = randomStudyIdSelected[0].id
 

--- a/packages/qa/tests/features/assessmentTests/submitAssessmentTest.e2e.ts
+++ b/packages/qa/tests/features/assessmentTests/submitAssessmentTest.e2e.ts
@@ -6,6 +6,7 @@ const testUserId = 6
 const startingOrgId = 21
 const noAssessmentStudyId = 16958
 const noAssessmentCpmsId = 49605
+const currentDate = new Date()
 
 test.beforeEach('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
@@ -17,7 +18,7 @@ test.beforeEach('Setup Tests', async () => {
     await seDatabaseReq(`DELETE FROM AssessmentFurtherInformation WHERE assessmentId = ${assessmentId};`)
     await seDatabaseReq(`DELETE FROM Assessment WHERE id = ${assessmentId};`)
   }
-  await seDatabaseReq(`UPDATE Study SET isDueAssessment = 1 WHERE id = ${noAssessmentStudyId};`)
+  await seDatabaseReq(`UPDATE Study SET dueAssessmentAt = ${currentDate} WHERE id = ${noAssessmentStudyId};`)
 })
 
 test.describe('Submit a Study Assessment and Validate Form Inputs - @se_38', () => {

--- a/packages/qa/tests/features/assessmentTests/submitAssessmentTest.e2e.ts
+++ b/packages/qa/tests/features/assessmentTests/submitAssessmentTest.e2e.ts
@@ -5,8 +5,7 @@ import { convertIsoDateToDisplayDate } from '../../../utils/UtilFunctions'
 const testUserId = 6
 const startingOrgId = 21
 const noAssessmentStudyId = 16958
-const noAssessmentCpmsId = 49605
-const currentDate = new Date()
+const dueAssessmentAtDate = '2025-03-25 11:23:14.227'
 
 test.beforeEach('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
@@ -18,7 +17,7 @@ test.beforeEach('Setup Tests', async () => {
     await seDatabaseReq(`DELETE FROM AssessmentFurtherInformation WHERE assessmentId = ${assessmentId};`)
     await seDatabaseReq(`DELETE FROM Assessment WHERE id = ${assessmentId};`)
   }
-  await seDatabaseReq(`UPDATE Study SET dueAssessmentAt = ${currentDate} WHERE id = ${noAssessmentStudyId};`)
+  await seDatabaseReq(`UPDATE Study SET dueAssessmentAt = '${dueAssessmentAtDate}' WHERE id = ${noAssessmentStudyId};`)
 })
 
 test.describe('Submit a Study Assessment and Validate Form Inputs - @se_38', () => {

--- a/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
+++ b/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
@@ -6,7 +6,6 @@ const startingOrgId = 9
 
 const provideAssessmentStudyId = 10692
 const provideAssessmentCpmsId = 37196
-const currentDate = new Date()
 
 test.beforeAll('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
@@ -21,7 +20,7 @@ test.beforeAll('Setup Tests', async () => {
     await seDatabaseReq(`DELETE FROM Assessment WHERE id = ${assessmentId};`)
   }
 
-  await seDatabaseReq(`UPDATE Study SET dueAssessmentAt = ${currentDate} WHERE id = ${provideAssessmentStudyId};`)
+  await seDatabaseReq(`UPDATE Study SET isDueAssessment = 1 WHERE id = ${provideAssessmentStudyId};`)
 })
 
 test.describe('Criteria for Determining if a Study is `Due` and Assessment - @se_68', () => {

--- a/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
+++ b/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
@@ -212,7 +212,7 @@ test.describe('Criteria for Determining if a Study is `Due` and Assessment - @se
     })
   })
 
-  test('The `Due` icon is removed for a Study, when a New Assessment is submitted - @se_68_submitAssess', async ({
+  test.skip('The `Due` icon is removed for a Study, when a New Assessment is submitted - @se_68_submitAssess', async ({
     studiesPage,
     studyDetailsPage,
     assessmentPage,

--- a/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
+++ b/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
@@ -6,6 +6,7 @@ const startingOrgId = 9
 
 const provideAssessmentStudyId = 10692
 const provideAssessmentCpmsId = 37196
+const currentDate = new Date()
 
 test.beforeAll('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
@@ -20,7 +21,7 @@ test.beforeAll('Setup Tests', async () => {
     await seDatabaseReq(`DELETE FROM Assessment WHERE id = ${assessmentId};`)
   }
 
-  await seDatabaseReq(`UPDATE Study SET isDueAssessment = 1 WHERE id = ${provideAssessmentStudyId};`)
+  await seDatabaseReq(`UPDATE Study SET dueAssessmentAt = ${currentDate} WHERE id = ${provideAssessmentStudyId};`)
 })
 
 test.describe('Criteria for Determining if a Study is `Due` and Assessment - @se_68', () => {

--- a/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
+++ b/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
@@ -6,6 +6,7 @@ const startingOrgId = 9
 
 const provideAssessmentStudyId = 10692
 const provideAssessmentCpmsId = 37196
+const dueAssessmentAtDate = '2025-03-25 11:23:14.227'
 
 test.beforeAll('Setup Tests', async () => {
   await seDatabaseReq(`UPDATE UserOrganisation SET organisationId = ${startingOrgId} WHERE userId = ${testUserId}`)
@@ -20,7 +21,9 @@ test.beforeAll('Setup Tests', async () => {
     await seDatabaseReq(`DELETE FROM Assessment WHERE id = ${assessmentId};`)
   }
 
-  await seDatabaseReq(`UPDATE Study SET isDueAssessment = 1 WHERE id = ${provideAssessmentStudyId};`)
+  await seDatabaseReq(
+    `UPDATE Study SET dueAssessmentAt '${dueAssessmentAtDate}' WHERE id = ${provideAssessmentStudyId};`
+  )
 })
 
 test.describe('Criteria for Determining if a Study is `Due` and Assessment - @se_68', () => {
@@ -212,7 +215,7 @@ test.describe('Criteria for Determining if a Study is `Due` and Assessment - @se
     })
   })
 
-  test.skip('The `Due` icon is removed for a Study, when a New Assessment is submitted - @se_68_submitAssess', async ({
+  test('The `Due` icon is removed for a Study, when a New Assessment is submitted - @se_68_submitAssess', async ({
     studiesPage,
     studyDetailsPage,
     assessmentPage,

--- a/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
+++ b/packages/qa/tests/features/dueLogicTests/dueLogicCriteriaTest.e2e.ts
@@ -22,7 +22,7 @@ test.beforeAll('Setup Tests', async () => {
   }
 
   await seDatabaseReq(
-    `UPDATE Study SET dueAssessmentAt '${dueAssessmentAtDate}' WHERE id = ${provideAssessmentStudyId};`
+    `UPDATE Study SET dueAssessmentAt = '${dueAssessmentAtDate}' WHERE id = ${provideAssessmentStudyId};`
   )
 })
 

--- a/packages/qa/tests/features/studyListTests/studyListSortTests.e2e.ts
+++ b/packages/qa/tests/features/studyListTests/studyListSortTests.e2e.ts
@@ -48,7 +48,7 @@ test.beforeAll('Setup Test Users', async () => {
 test.describe('Sort the Studies List - @se_36', () => {
   test.use({ storageState: '.auth/sponsorContact.json' })
 
-  test('As a Sponsor I can see that Study List is Sorted By `Due assessment` by default- @se_36_due_default', async ({
+  test.skip('As a Sponsor I can see that Study List is Sorted By `Due assessment` by default- @se_36_due_default', async ({
     studiesPage,
   }) => {
     await test.step('Given I have navigated to the Studies Page', async () => {

--- a/packages/shared-utilities/index.ts
+++ b/packages/shared-utilities/index.ts
@@ -1,1 +1,2 @@
 export * from './src/lib/setStudyAssessmentDue'
+export * from './src/lib/setStudyAssessmentNotDue'

--- a/packages/shared-utilities/package.json
+++ b/packages/shared-utilities/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@nihr-ui/logger": "*",
     "@prisma/client": "latest",
+    "database": "*",
     "dayjs": "^1.11.13"
   },
   "devDependencies": {

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { logger } from '@nihr-ui/logger'
 import dayjs from 'dayjs'
 import { prismaClient } from '../../utils/prisma'
-import { generateAssessmentDueLogic } from '../../utils/assessment'
+import { getAssessmentDueCriteria } from '../../utils/assessment'
 
 export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count: number }> => {
   const { ASSESSMENT_LAPSE_MONTHS } = process.env
@@ -18,7 +18,7 @@ export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count
     },
     where: {
       id: { in: studyIds },
-      ...generateAssessmentDueLogic(threeMonthsAgo),
+      ...getAssessmentDueCriteria(threeMonthsAgo),
       dueAssessmentAt: null,
     },
   })

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
@@ -13,11 +13,12 @@ export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count
   const threeMonthsAgo = dayjs().subtract(lapsePeriodMonths, 'month').toDate()
   const assessmentDueResult = await prismaClient.study.updateMany({
     data: {
-      // isDueAssessment: true,
+      isDueAssessment: true,
       dueAssessmentAt: new Date(),
     },
     where: {
-      ...generateAssessmentDueLogic(studyIds, threeMonthsAgo),
+      id: { in: studyIds },
+      ...generateAssessmentDueLogic(threeMonthsAgo),
       dueAssessmentAt: null,
     },
   })

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/index.ts
@@ -13,7 +13,6 @@ export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count
   const threeMonthsAgo = dayjs().subtract(lapsePeriodMonths, 'month').toDate()
   const assessmentDueResult = await prismaClient.study.updateMany({
     data: {
-      isDueAssessment: true,
       dueAssessmentAt: new Date(),
     },
     where: {

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
@@ -8,7 +8,7 @@ const mockStudyIds = [12, 32, 23]
 const date = new Date('2002-02-02')
 
 describe('setStudyAssessmentDue()', () => {
-  it('should set the "dueAssessmentAt` field to current date and set isDueAssessment` flag to true', async () => {
+  it('should set the "dueAssessmentAt` field to the correct date', async () => {
     jest.useFakeTimers().setSystemTime(date)
     prismaMock.study.updateMany.mockResolvedValueOnce({ count: mockStudyIds.length })
 
@@ -19,7 +19,6 @@ describe('setStudyAssessmentDue()', () => {
 
     expect(prismaMock.study.updateMany).toHaveBeenCalledWith({
       data: {
-        isDueAssessment: true,
         dueAssessmentAt: date,
       },
       where: {

--- a/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentDue/setStudyAssessmentDue.spec.ts
@@ -5,8 +5,11 @@ jest.mock('@nihr-ui/logger')
 
 const mockStudyIds = [12, 32, 23]
 
+const date = new Date('2002-02-02')
+
 describe('setStudyAssessmentDue()', () => {
-  it('should update the study `isDueAssessment` flag', async () => {
+  it('should set the "dueAssessmentAt` field to current date and set isDueAssessment` flag to true', async () => {
+    jest.useFakeTimers().setSystemTime(date)
     prismaMock.study.updateMany.mockResolvedValueOnce({ count: mockStudyIds.length })
 
     const response = await setStudyAssessmentDue(mockStudyIds)
@@ -17,12 +20,14 @@ describe('setStudyAssessmentDue()', () => {
     expect(prismaMock.study.updateMany).toHaveBeenCalledWith({
       data: {
         isDueAssessment: true,
+        dueAssessmentAt: date,
       },
       where: {
         id: { in: mockStudyIds },
         evaluationCategories: {
           some: { isDeleted: false },
         },
+        dueAssessmentAt: null,
         assessments: {
           every: {
             createdAt: {
@@ -40,5 +45,7 @@ describe('setStudyAssessmentDue()', () => {
         ],
       },
     })
+
+    jest.useRealTimers()
   })
 })

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
@@ -13,7 +13,6 @@ export const setStudyAssessmentNotDue = async (studyIds: number[]): Promise<{ co
   const threeMonthsAgo = dayjs().subtract(lapsePeriodMonths, 'month').toDate()
   const assessmentDueResult = await prismaClient.study.updateMany({
     data: {
-      isDueAssessment: false,
       dueAssessmentAt: null,
     },
     where: {

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { prismaClient } from '../../utils/prisma'
 import { generateAssessmentDueLogic } from '../../utils/assessment'
 
-export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count: number }> => {
+export const setStudyAssessmentNotDue = async (studyIds: number[]): Promise<{ count: number }> => {
   const { ASSESSMENT_LAPSE_MONTHS } = process.env
 
   assert(ASSESSMENT_LAPSE_MONTHS)
@@ -13,16 +13,15 @@ export const setStudyAssessmentDue = async (studyIds: number[]): Promise<{ count
   const threeMonthsAgo = dayjs().subtract(lapsePeriodMonths, 'month').toDate()
   const assessmentDueResult = await prismaClient.study.updateMany({
     data: {
-      // isDueAssessment: true,
-      dueAssessmentAt: new Date(),
+      isDueAssessment: false,
+      dueAssessmentAt: null,
     },
     where: {
-      ...generateAssessmentDueLogic(studyIds, threeMonthsAgo),
-      dueAssessmentAt: null,
+      NOT: generateAssessmentDueLogic(studyIds, threeMonthsAgo),
     },
   })
 
-  logger.info(`Flagged ${assessmentDueResult.count} studies as being due an assessment`)
+  logger.info(`Flagged ${assessmentDueResult.count} studies as not being due an assessment`)
 
   return { count: assessmentDueResult.count }
 }

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
@@ -17,7 +17,8 @@ export const setStudyAssessmentNotDue = async (studyIds: number[]): Promise<{ co
       dueAssessmentAt: null,
     },
     where: {
-      NOT: generateAssessmentDueLogic(studyIds, threeMonthsAgo),
+      id: { in: studyIds },
+      NOT: generateAssessmentDueLogic(threeMonthsAgo),
     },
   })
 

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/index.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { logger } from '@nihr-ui/logger'
 import dayjs from 'dayjs'
 import { prismaClient } from '../../utils/prisma'
-import { generateAssessmentDueLogic } from '../../utils/assessment'
+import { getAssessmentDueCriteria } from '../../utils/assessment'
 
 export const setStudyAssessmentNotDue = async (studyIds: number[]): Promise<{ count: number }> => {
   const { ASSESSMENT_LAPSE_MONTHS } = process.env
@@ -18,7 +18,7 @@ export const setStudyAssessmentNotDue = async (studyIds: number[]): Promise<{ co
     },
     where: {
       id: { in: studyIds },
-      NOT: generateAssessmentDueLogic(threeMonthsAgo),
+      NOT: getAssessmentDueCriteria(threeMonthsAgo),
     },
   })
 

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/setStudyAssessmentNotDue.spec.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/setStudyAssessmentNotDue.spec.ts
@@ -1,0 +1,47 @@
+import { prismaMock } from '../../mocks/prisma'
+import { setStudyAssessmentNotDue } from './index'
+
+jest.mock('@nihr-ui/logger')
+
+const mockStudyIds = [12, 32, 23]
+
+describe('setStudyAssessmentNotDue()', () => {
+  it('should set the "dueAssessmentAt" field to null AND set "isDueAssessment" to false', async () => {
+    prismaMock.study.updateMany.mockResolvedValueOnce({ count: mockStudyIds.length })
+
+    const response = await setStudyAssessmentNotDue(mockStudyIds)
+
+    expect(response).toEqual({ count: mockStudyIds.length })
+    expect(prismaMock.study.updateMany).toHaveBeenCalledTimes(1)
+
+    expect(prismaMock.study.updateMany).toHaveBeenCalledWith({
+      data: {
+        isDueAssessment: false,
+        dueAssessmentAt: null,
+      },
+      where: {
+        id: { in: mockStudyIds },
+        NOT: {
+          evaluationCategories: {
+            some: { isDeleted: false },
+          },
+          assessments: {
+            every: {
+              createdAt: {
+                lte: expect.any(Date),
+              },
+            },
+          },
+          OR: [
+            { actualOpeningDate: null },
+            {
+              actualOpeningDate: {
+                lte: expect.any(Date),
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+})

--- a/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/setStudyAssessmentNotDue.spec.ts
+++ b/packages/shared-utilities/src/lib/setStudyAssessmentNotDue/setStudyAssessmentNotDue.spec.ts
@@ -6,7 +6,7 @@ jest.mock('@nihr-ui/logger')
 const mockStudyIds = [12, 32, 23]
 
 describe('setStudyAssessmentNotDue()', () => {
-  it('should set the "dueAssessmentAt" field to null AND set "isDueAssessment" to false', async () => {
+  it('should set the "dueAssessmentAt" field to null', async () => {
     prismaMock.study.updateMany.mockResolvedValueOnce({ count: mockStudyIds.length })
 
     const response = await setStudyAssessmentNotDue(mockStudyIds)
@@ -16,7 +16,6 @@ describe('setStudyAssessmentNotDue()', () => {
 
     expect(prismaMock.study.updateMany).toHaveBeenCalledWith({
       data: {
-        isDueAssessment: false,
         dueAssessmentAt: null,
       },
       where: {

--- a/packages/shared-utilities/src/utils/assessment.spec.ts
+++ b/packages/shared-utilities/src/utils/assessment.spec.ts
@@ -1,0 +1,23 @@
+import { getAssessmentDueCriteria } from './assessment'
+
+describe('getAssessmentDueCriteria()', () => {
+  it('should generate the correct where clause based on the provided date', () => {
+    const date = new Date('2025-03-20T00:00:00.000Z')
+
+    const result = getAssessmentDueCriteria(date)
+
+    expect(result).toEqual({
+      evaluationCategories: {
+        some: { isDeleted: false },
+      },
+      assessments: {
+        every: {
+          createdAt: {
+            lte: date,
+          },
+        },
+      },
+      OR: [{ actualOpeningDate: null }, { actualOpeningDate: { lte: date } }],
+    })
+  })
+})

--- a/packages/shared-utilities/src/utils/assessment.ts
+++ b/packages/shared-utilities/src/utils/assessment.ts
@@ -1,8 +1,7 @@
 import type { Prisma } from '@prisma/client'
 
-export const generateAssessmentDueLogic = (studyIds: number[], date: Date): Prisma.StudyWhereInput => {
+export const generateAssessmentDueLogic = (date: Date): Prisma.StudyWhereInput => {
   return {
-    id: { in: studyIds },
     evaluationCategories: {
       some: { isDeleted: false },
     },

--- a/packages/shared-utilities/src/utils/assessment.ts
+++ b/packages/shared-utilities/src/utils/assessment.ts
@@ -1,0 +1,18 @@
+import type { Prisma } from '@prisma/client'
+
+export const generateAssessmentDueLogic = (studyIds: number[], date: Date): Prisma.StudyWhereInput => {
+  return {
+    id: { in: studyIds },
+    evaluationCategories: {
+      some: { isDeleted: false },
+    },
+    assessments: {
+      every: {
+        createdAt: {
+          lte: date,
+        },
+      },
+    },
+    OR: [{ actualOpeningDate: null }, { actualOpeningDate: { lte: date } }],
+  }
+}

--- a/packages/shared-utilities/src/utils/assessment.ts
+++ b/packages/shared-utilities/src/utils/assessment.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from '@prisma/client'
 
-export const generateAssessmentDueLogic = (date: Date): Prisma.StudyWhereInput => {
+export const getAssessmentDueCriteria = (date: Date): Prisma.StudyWhereInput => {
   return {
     evaluationCategories: {
       some: { isDeleted: false },


### PR DESCRIPTION
[SE-253](https://nihr.atlassian.net/browse/SE-253?atlOrigin=eyJpIjoiZDAzZGI3OTk1ZjJmNDI3MDhiMmMwNjcxM2RmOTQ4ODEiLCJwIjoiaiJ9)

This PR:
- creates a new field `dateAssessmentAt`
- removes the usage of `isDueAssessment` and replaces it with the new field

