### PR TITLE
SE-251: Surface invite failures to the UI 

### DIFF
--- a/apps/web/src/__tests__/Organisation.spec.tsx
+++ b/apps/web/src/__tests__/Organisation.spec.tsx
@@ -97,6 +97,13 @@ const mockOrganisation = Mock.of<OrganisationWithRelations>({
       },
       createdAt: new Date('2001-01-01'),
       updatedAt: new Date('2001-01-02'),
+      invitations: [
+        {
+          status: {
+            name: 'Failure',
+          },
+        },
+      ],
     },
     {
       id: 2,
@@ -107,6 +114,7 @@ const mockOrganisation = Mock.of<OrganisationWithRelations>({
       },
       createdAt: new Date('2001-01-01'),
       updatedAt: new Date('2001-01-02'),
+      invitations: [],
     },
   ],
 })
@@ -174,7 +182,7 @@ describe('Organisation page', () => {
 
     expect(contactCells).toEqual([
       'test1@test1.com',
-      '2 January 2001',
+      '2 January 2001Failed to deliver email',
       '3 January 2001 ',
       'Remove',
       'test2@test2.com',

--- a/apps/web/src/constants/identifiers.ts
+++ b/apps/web/src/constants/identifiers.ts
@@ -26,4 +26,4 @@ export enum StudyUpdateState {
  * The status of an invitation email
  * This should match the values in SysRefInvitationStatus table
  */
-export const UserOrganisationInviteStatus = { SUCCESS: 'Success', FAILED: 'Failed', PENDING: 'Pending' }
+export const UserOrganisationInviteStatus = { SUCCESS: 'Success', FAILURE: 'Failure', PENDING: 'Pending' }

--- a/apps/web/src/lib/organisations.ts
+++ b/apps/web/src/lib/organisations.ts
@@ -110,6 +110,20 @@ const organisationByIdRelations = {
       },
       include: {
         user: true,
+        invitations: {
+          select: {
+            status: {
+              select: {
+                name: true,
+              },
+            },
+          },
+          where: {
+            isDeleted: false,
+          },
+          distinct: [Prisma.UserOrganisationInvitationScalarFieldEnum.userOrganisationId],
+          orderBy: { timestamp: Prisma.SortOrder.desc },
+        },
       },
       orderBy: {
         updatedAt: Prisma.SortOrder.desc,

--- a/apps/web/src/pages/api/forms/organisation.spec.ts
+++ b/apps/web/src/pages/api/forms/organisation.spec.ts
@@ -221,6 +221,7 @@ describe('Successful organisation sponsor contact invitation', () => {
             id: createUserOrgInvitation.userOrganisationId,
           },
         },
+        sentBy: { connect: { id: userWithContactManagerRole.user?.id } },
       },
     })
 
@@ -381,6 +382,11 @@ describe('Successful organisation sponsor contact invitation', () => {
             id: createUserOrgInvitation.userOrganisationId,
           },
         },
+        sentBy: {
+          connect: {
+            id: userWithContactManagerRole.user?.id,
+          },
+        },
       },
     })
 
@@ -519,6 +525,11 @@ describe('Successful organisation sponsor contact invitation', () => {
         userOrganisation: {
           connect: {
             id: createUserOrgInvitation.userOrganisationId,
+          },
+        },
+        sentBy: {
+          connect: {
+            id: userWithContactManagerRole.user?.id,
           },
         },
       },

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -210,6 +210,11 @@ export default withApiHandler<ExtendedNextApiRequest>(
               id: userOrganisationId,
             },
           },
+          sentBy: {
+            connect: {
+              id: requestedByUserId,
+            },
+          },
         },
       })
 

--- a/apps/web/src/pages/api/forms/removeContact.spec.ts
+++ b/apps/web/src/pages/api/forms/removeContact.spec.ts
@@ -58,6 +58,7 @@ describe('Successful remove organisation contact', () => {
   ])('Removing user from an organisation', async (userSession: Session) => {
     jest.mocked(getServerSession).mockResolvedValueOnce(userSession)
     jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValueOnce(mockUserOrganisation)
+    jest.mocked(prismaClient.userOrganisationInvitation.updateMany).mockResolvedValueOnce({ count: 1 })
 
     const updateUserOrgMock = jest
       .mocked(prismaClient.userOrganisation.update)
@@ -93,6 +94,15 @@ describe('Successful remove organisation contact', () => {
     // Redirect back to organisation page
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/organisations/${mockUserOrganisation.organisation.id}?success=2`)
+
+    expect(prismaClient.userOrganisationInvitation.updateMany).toHaveBeenCalledWith({
+      where: {
+        userOrganisationId: mockUserOrganisation.id,
+      },
+      data: {
+        isDeleted: true,
+      },
+    })
   })
 })
 

--- a/apps/web/src/pages/api/forms/removeContact.ts
+++ b/apps/web/src/pages/api/forms/removeContact.ts
@@ -69,6 +69,18 @@ export default withApiHandler<ExtendedNextApiRequest>(
 
       logger.info('Removed contact with email %s from organisation %s', user.email, organisation.name)
 
+      // Remove corresponding entries in UserOrganisationInvitation table
+      await prismaClient.userOrganisationInvitation.updateMany({
+        where: {
+          userOrganisationId: Number(userOrganisationId),
+        },
+        data: {
+          isDeleted: true, // TODO: make sure to update nightly jobs to filter by isDeleted field
+        },
+      })
+
+      logger.info('Successfully removed entry in UserOrganisationInvitation table')
+
       const isEligibleForOdpRole = await isUserEligibleForOdpRole(user.id)
 
       if (!isEligibleForOdpRole) {

--- a/apps/web/src/pages/api/forms/removeContact.ts
+++ b/apps/web/src/pages/api/forms/removeContact.ts
@@ -75,7 +75,7 @@ export default withApiHandler<ExtendedNextApiRequest>(
           userOrganisationId: Number(userOrganisationId),
         },
         data: {
-          isDeleted: true, // TODO: make sure to update nightly jobs to filter by isDeleted field
+          isDeleted: true,
         },
       })
 

--- a/apps/web/src/pages/organisations/[organisationId]/index.tsx
+++ b/apps/web/src/pages/organisations/[organisationId]/index.tsx
@@ -12,7 +12,7 @@ import { useForm } from 'react-hook-form'
 import { ErrorSummary, Form } from '@/components/atoms'
 import { TextInput } from '@/components/atoms/Form/TextInput/TextInput'
 import { RootLayout } from '@/components/organisms'
-import { Roles } from '@/constants'
+import { Roles, UserOrganisationInviteStatus } from '@/constants'
 import { useFormErrorHydration } from '@/hooks/useFormErrorHydration'
 import { getOrganisationById } from '@/lib/organisations'
 import { formatDate } from '@/utils/date'
@@ -101,7 +101,14 @@ export default function Organisation({ organisation, query }: OrganisationProps)
           {organisation.users.map((user) => (
             <Table.Row key={user.id}>
               <Table.Cell>{user.user.email}</Table.Cell>
-              <Table.Cell>{formatDate(user.updatedAt)}</Table.Cell>
+              <Table.Cell>
+                <div className="flex flex-col gap-2 w-fit">
+                  {formatDate(user.updatedAt)}
+                  {user.invitations[0]?.status.name === UserOrganisationInviteStatus.FAILURE ? (
+                    <span className="govuk-tag govuk-tag--red normal-case">Failed to deliver email</span>
+                  ) : null}
+                </div>
+              </Table.Cell>
               <Table.Cell>{user.user.lastLogin ? formatDate(user.user.lastLogin) : '-'} </Table.Cell>
               <Table.Cell>
                 <Link aria-label={`Remove ${user.user.email}`} href={`/organisations/remove-contact/${user.id}`}>

--- a/packages/database/prisma/migrations/20250404132009_updated_user_organisation_invitations/migration.sql
+++ b/packages/database/prisma/migrations/20250404132009_updated_user_organisation_invitations/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `sentById` to the `UserOrganisationInvitation` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `UserOrganisationInvitation` ADD COLUMN `isDeleted` BOOLEAN NULL DEFAULT false,
+    ADD COLUMN `sentById` INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `UserOrganisationInvitation` ADD CONSTRAINT `UserOrganisationInvitation_sentById_fkey` FOREIGN KEY (`sentById`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20250404132009_updated_user_organisation_invitations/migration.sql
+++ b/packages/database/prisma/migrations/20250404132009_updated_user_organisation_invitations/migration.sql
@@ -1,12 +1,20 @@
-/*
-  Warnings:
-
-  - Added the required column `sentById` to the `UserOrganisationInvitation` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- AlterTable
 ALTER TABLE `UserOrganisationInvitation` ADD COLUMN `isDeleted` BOOLEAN NULL DEFAULT false,
-    ADD COLUMN `sentById` INTEGER NOT NULL;
+    ADD COLUMN `sentById` INTEGER  NULL;
+
+
+-- Set `sentById` field to the 'Adminstrator' User id
+UPDATE `UserOrganisationInvitation` userOrgInvitation 
+JOIN  (
+  SELECT `id`
+  FROM `User`
+  WHERE `email` = 'administrator@nihr.ac.uk'
+  LIMIT 1
+) AS adminUser
+SET userOrgInvitation.`sentById` = adminUser.`id`;
+
+--- Update `sentById` field to be required
+ALTER TABLE `UserOrganisationInvitation` MODIFY COLUMN `sentById` INT NOT NULL;
 
 -- AddForeignKey
 ALTER TABLE `UserOrganisationInvitation` ADD CONSTRAINT `UserOrganisationInvitation_sentById_fkey` FOREIGN KEY (`sentById`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -72,24 +72,25 @@ model OrganisationRole {
 }
 
 model User {
-  id                    Int                  @id @default(autoincrement())
-  name                  String?
-  email                 String               @unique
-  identityGatewayId     String?
-  registrationToken     String?
-  registrationConfirmed Boolean?             @default(false)
-  isDeleted             Boolean?             @default(false)
-  lastLogin             DateTime?
-  organisations         UserOrganisation[]   @relation(name: "userOrganisation")
-  createdOrganisations  UserOrganisation[]   @relation(name: "createdOrganisations")
-  updatedOrganisations  UserOrganisation[]   @relation(name: "updatedOrganisations")
-  roles                 UserRole[]           @relation(name: "userRoles")
-  createdRoles          UserRole[]           @relation(name: "createdRoles")
-  updatedRoles          UserRole[]           @relation(name: "updatedRoles")
-  assessments           Assessment[]
-  assessmentReminders   AssessmentReminder[]
-  createdStudyUpdates   StudyUpdates[]       @relation(name: "createdStudyUpdates")
-  modifiedStudyUpdates  StudyUpdates[]       @relation(name: "modifiedStudyUpdates")
+  id                          Int                          @id @default(autoincrement())
+  name                        String?
+  email                       String                       @unique
+  identityGatewayId           String?
+  registrationToken           String?
+  registrationConfirmed       Boolean?                     @default(false)
+  isDeleted                   Boolean?                     @default(false)
+  lastLogin                   DateTime?
+  organisations               UserOrganisation[]           @relation(name: "userOrganisation")
+  createdOrganisations        UserOrganisation[]           @relation(name: "createdOrganisations")
+  updatedOrganisations        UserOrganisation[]           @relation(name: "updatedOrganisations")
+  roles                       UserRole[]                   @relation(name: "userRoles")
+  createdRoles                UserRole[]                   @relation(name: "createdRoles")
+  updatedRoles                UserRole[]                   @relation(name: "updatedRoles")
+  assessments                 Assessment[]
+  assessmentReminders         AssessmentReminder[]
+  createdStudyUpdates         StudyUpdates[]               @relation(name: "createdStudyUpdates")
+  modifiedStudyUpdates        StudyUpdates[]               @relation(name: "modifiedStudyUpdates")
+  organisationInvitationsSent UserOrganisationInvitation[] @relation(name: "userOrganisationInvitationsSent")
 }
 
 model UserRole {
@@ -110,26 +111,26 @@ model UserRole {
 }
 
 model UserOrganisation {
-  id                         Int                          @id @default(autoincrement())
-  user                       User                         @relation(name: "userOrganisation", fields: [userId], references: [id])
-  userId                     Int
-  organisation               Organisation                 @relation(fields: [organisationId], references: [id])
-  organisationId             Int
-  createdBy                  User                         @relation(name: "createdOrganisations", fields: [createdById], references: [id])
-  createdById                Int
-  updatedBy                  User                         @relation(name: "updatedOrganisations", fields: [updatedById], references: [id])
-  updatedById                Int
-  createdAt                  DateTime                     @default(now())
-  updatedAt                  DateTime                     @updatedAt
-  isDeleted                  Boolean?                     @default(false)
-  UserOrganisationInvitation UserOrganisationInvitation[]
+  id             Int                          @id @default(autoincrement())
+  user           User                         @relation(name: "userOrganisation", fields: [userId], references: [id])
+  userId         Int
+  organisation   Organisation                 @relation(fields: [organisationId], references: [id])
+  organisationId Int
+  createdBy      User                         @relation(name: "createdOrganisations", fields: [createdById], references: [id])
+  createdById    Int
+  updatedBy      User                         @relation(name: "updatedOrganisations", fields: [updatedById], references: [id])
+  updatedById    Int
+  createdAt      DateTime                     @default(now())
+  updatedAt      DateTime                     @updatedAt
+  isDeleted      Boolean?                     @default(false)
+  invitations    UserOrganisationInvitation[] @relation(name: "userOrganisationInvitations")
 
   @@unique([userId, organisationId])
 }
 
 model UserOrganisationInvitation {
   id                 Int                    @id @default(autoincrement())
-  userOrganisation   UserOrganisation       @relation(fields: [userOrganisationId], references: [id])
+  userOrganisation   UserOrganisation       @relation(name: "userOrganisationInvitations", fields: [userOrganisationId], references: [id])
   userOrganisationId Int
   messageId          String
   timestamp          DateTime
@@ -138,6 +139,9 @@ model UserOrganisationInvitation {
   failureNotifiedAt  DateTime?
   createdAt          DateTime               @default(now())
   updatedAt          DateTime               @updatedAt
+  sentById           Int
+  sentBy             User                   @relation(name: "userOrganisationInvitationsSent", fields: [sentById], references: [id])
+  isDeleted          Boolean?               @default(false)
 }
 
 model StudyOrganisation {
@@ -306,5 +310,5 @@ model SysRefOrganisationRole {
 model SysRefInvitationStatus {
   id                         Int                          @id @default(autoincrement())
   name                       String
-  UserOrganisationInvitation UserOrganisationInvitation[]
+  userOrganisationInvitation UserOrganisationInvitation[]
 }


### PR DESCRIPTION
This PR:
- updates the `userOrganisationInvitation` table to include `isDeleted` and `sentBy` fields
- surfaces failed user invites to the UI 