### PR TITLE
SE-252: Update 'search organisation' functionality 

### DIFF
--- a/apps/web/src/__tests__/Organisations.spec.tsx
+++ b/apps/web/src/__tests__/Organisations.spec.tsx
@@ -270,7 +270,7 @@ describe('Organisations page', () => {
     }
     render(Organisations.getLayout(<Organisations {...props} />, { ...props }))
 
-    expect(screen.getByLabelText('Search organisation name')).toHaveValue('test search')
+    expect(screen.getByLabelText('Search by organisation name or contact email address')).toHaveValue('test search')
 
     expect(screen.getByText('Selected filters')).toBeInTheDocument()
 

--- a/apps/web/src/lib/organisations.ts
+++ b/apps/web/src/lib/organisations.ts
@@ -96,9 +96,6 @@ export const getStudyOrganisations = async ({
       studies: {
         some: {},
       },
-      users: {
-        some: {},
-      },
       ...(userId !== undefined && userOrgsQuery),
       isDeleted: false,
     },

--- a/apps/web/src/lib/organisations.ts
+++ b/apps/web/src/lib/organisations.ts
@@ -72,11 +72,31 @@ export const getStudyOrganisations = async ({
     orderBy: [{ name: Prisma.SortOrder.asc }],
     where: {
       ...(searchTerm && {
-        name: {
-          contains: searchTerm,
-        },
+        OR: [
+          {
+            name: {
+              contains: searchTerm,
+            },
+          },
+          {
+            users: {
+              some: {
+                user: {
+                  is: {
+                    email: searchTerm,
+                    isDeleted: false,
+                  },
+                },
+                isDeleted: false,
+              },
+            },
+          },
+        ],
       }),
       studies: {
+        some: {},
+      },
+      users: {
         some: {},
       },
       ...(userId !== undefined && userOrgsQuery),

--- a/apps/web/src/pages/organisations/index.tsx
+++ b/apps/web/src/pages/organisations/index.tsx
@@ -42,7 +42,11 @@ export default function Organisations({
 
           {/* Search/Filter bar */}
           <div>
-            <Filters filters={filters} onFilterChange={handleFilterChange} searchLabel="Search organisation name" />
+            <Filters
+              filters={filters}
+              onFilterChange={handleFilterChange}
+              searchLabel="Search by organisation name or contact email address"
+            />
           </div>
 
           <SelectedFilters filters={filters} isLoading={isLoading} />


### PR DESCRIPTION
This PR updates the search organisations functionality to allow for email addresses. It takes into considerations, if a user is deleted and if a user has been removed from that organisation.