### PR TITLE
SE-251: Update retry logic based on error type

### DIFF
--- a/.github/workflows/execute-scheduled-task.yml
+++ b/.github/workflows/execute-scheduled-task.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Restore Original Schedule (invitation-monitor)
         if: github.event.inputs.appname == 'invitation-monitor'
         run: |
-          aws events put-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule --schedule-expression "cron(0 18 * * ? *)"
+          aws events put-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule --schedule-expression "cron(0 16 * * ? *)"
           aws events enable-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule
 
 

--- a/apps/invitation-monitor/src/lib/constants.ts
+++ b/apps/invitation-monitor/src/lib/constants.ts
@@ -7,3 +7,16 @@ import { EventType } from '@aws-sdk/client-sesv2'
 export const UserOrganisationInviteStatus = { SUCCESS: 'Success', FAILURE: 'Failure', PENDING: 'Pending' }
 
 export const PERMANENT_EMAIL_FAILURES: string[] = [EventType.RENDERING_FAILURE, EventType.REJECT]
+
+/**
+ * A list of Amazon SES errors that we want to attempt a retry after receiving
+ */
+export const RETRYABLE_SES_ERRORS = [
+  'InternalFailure',
+  'RequestAbortedException',
+  'RequestExpired',
+  'RequestTimeoutException',
+  'ServiceUnavailable',
+  'ThrottlingException',
+  'TooManyRequestsException',
+]

--- a/apps/invitation-monitor/src/tests/index.spec.ts
+++ b/apps/invitation-monitor/src/tests/index.spec.ts
@@ -93,7 +93,7 @@ describe('monitorInvitationEmails', () => {
 
     await expect(promise).resolves.not.toThrow()
 
-    expect(mockEmailDeliverabilityService.getEmailInsights).toHaveBeenCalledTimes(3) // Retries two times
+    expect(mockEmailDeliverabilityService.getEmailInsights).toHaveBeenCalledTimes(1)
 
     jest.useRealTimers()
   })


### PR DESCRIPTION
As part of this PR, the AWS common errors and `getMessageInsights` API errors have been split into two groups - retry-able and fatal errors.

https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_GetMessageInsights.html#API_GetMessageInsights_Errors
https://docs.aws.amazon.com/ses/latest/APIReference-V2/CommonErrors.html

Retry-able:
InternalFailure
RequestAbortedException
RequestExpired
RequestTimeoutException
ServiceUnavailable
ThrottlingException
TooManyRequestsException

Fatal:
AccessDeniedException
ExpiredTokenException
IncompleteSignature
MalformedHttpRequestException
NotAuthorized
OptInRequired
UnrecognizedClientException
UnknownOperationException
ValidationError
BadRequestException
NotFoundException
RequestEntityTooLargeException

The PR also updates the invitation-monitor task on UAT to run at 4pm. 