### PR TITLE
Fix: Update UAT workflow to UTC 

### DIFF
--- a/.github/workflows/execute-scheduled-task.yml
+++ b/.github/workflows/execute-scheduled-task.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Restore Original Schedule (invitation-monitor)
         if: github.event.inputs.appname == 'invitation-monitor'
         run: |
-          aws events put-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule --schedule-expression "cron(0 16 * * ? *)"
+          aws events put-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule --schedule-expression "cron(0 15 * * ? *)"
           aws events enable-rule --name crnccs-ecs-uat-se-${{ github.event.inputs.appname}}-cw-event-rule
 
 


### PR DESCRIPTION
Temporarily change UAT invitation-monitor job to run 15:00 UTC. 