### PR TITLE
SE-251: Run requests sequentially

### DIFF
--- a/apps/invitation-monitor/src/lib/constants.ts
+++ b/apps/invitation-monitor/src/lib/constants.ts
@@ -20,3 +20,5 @@ export const RETRYABLE_SES_ERRORS = [
   'ThrottlingException',
   'TooManyRequestsException',
 ]
+
+export const AWS_GET_MESSAGE_INSIGHTS_RATE_LIMIT_MS = 1000


### PR DESCRIPTION
This PR resolves an issue where we are getting consistently rate limited when fetching message insights from AWS. 

This solution runs each request sequentially to reduce the chances of making more than 1 request per second. From running this locally with ~ 300 pending emails, rate limit was only hit once and the retry logic we have in place, prevented another rate limit. (Appreciate the server will likely run faster than my machine, but given the retry logic that is in place, I think we're safe to rely on that.) 

**Why?**
While exploring different strategies (e.g. batching and random delays before making request), we consistently hit AWS's rate limit of 1 request per second. Even with delay mechanisms and retry logic in place, the initial batch or group of requests often exceeded the allowed threshold. 

**Considerations**
While this may impact performance slightly for large batches, it offers a more reliable given the current constraint. 