### PR TITLE
feat: update email on error pages

### DIFF
--- a/apps/web/src/__tests__/404.spec.tsx
+++ b/apps/web/src/__tests__/404.spec.tsx
@@ -3,11 +3,11 @@ import { render } from '@/config/TestUtils'
 import PageNotFound from '../pages/404'
 
 test('Displays the 404 page', () => {
-  const { getByText, getByRole } = render(PageNotFound.getLayout(<PageNotFound />))
+  const { getByText, getByRole, getByTestId } = render(PageNotFound.getLayout(<PageNotFound />))
 
   expect(getByRole('heading', { name: 'Assess progress of studies', level: 1 }))
   expect(getByRole('heading', { name: 'Page not found', level: 2 }))
   expect(getByText('If you typed the web address, check it is correct.')).toBeInTheDocument()
   expect(getByText('If you pasted the web address, check you copied the entire address.')).toBeInTheDocument()
-  expect(getByText('Please contact crn.servicedesk@nihr.ac.uk for further assistance.')).toBeInTheDocument()
+  expect(getByTestId('PageNotFoundContactForAssistance')).toBeInTheDocument()
 })

--- a/apps/web/src/__tests__/500.spec.tsx
+++ b/apps/web/src/__tests__/500.spec.tsx
@@ -3,9 +3,9 @@ import { render } from '@/config/TestUtils'
 import ServiceUnavailable from '../pages/500'
 
 test('Displays the 500 page', () => {
-  const { getByText, getByRole } = render(ServiceUnavailable.getLayout(<ServiceUnavailable />))
+  const { getByRole, getByTestId } = render(ServiceUnavailable.getLayout(<ServiceUnavailable />))
 
   expect(getByRole('heading', { name: 'Assess progress of studies', level: 1 }))
   expect(getByRole('heading', { name: 'Sorry, there is a problem with the service', level: 2 }))
-  expect(getByText('Please contact crn.servicedesk@nihr.ac.uk for further assistance.')).toBeInTheDocument()
+  expect(getByTestId('ErrorContactForAssitance')).toBeInTheDocument()
 })

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -11,7 +11,10 @@ export default function PageNotFound() {
           <h2 className="govuk-heading-l">Page not found</h2>
           <p className="govuk-body">If you typed the web address, check it is correct.</p>
           <p className="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-          <p className="govuk-body">Please contact crn.servicedesk@nihr.ac.uk for further assistance.</p>
+          <p className="govuk-body" data-testid="PageNotFoundContactForAssistance">
+            Please contact <a href="mailto:rdn.servicedesk@nihr.ac.uk">rdn.servicedesk@nihr.ac.uk</a> for further
+            assistance.
+          </p>
         </div>
       </div>
     </Container>

--- a/apps/web/src/pages/500.tsx
+++ b/apps/web/src/pages/500.tsx
@@ -9,7 +9,10 @@ export default function ServiceUnavailable() {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h2 className="govuk-heading-l">Sorry, there is a problem with the service</h2>
-          <p className="govuk-body">Please contact crn.servicedesk@nihr.ac.uk for further assistance.</p>
+          <p className="govuk-body" data-testid="ErrorContactForAssitance">
+            Please contact <a href="mailto:rdn.servicedesk@nihr.ac.uk">rdn.servicedesk@nihr.ac.uk</a> for further
+            assistance.
+          </p>
         </div>
       </div>
     </Container>

--- a/packages/qa/pages/CommonItemsPage.ts
+++ b/packages/qa/pages/CommonItemsPage.ts
@@ -123,7 +123,7 @@ export default class CommonItemsPage {
     await expect(this.txtGenericErrorGuidance).toBeVisible()
     await expect(this.pageTitle).toHaveText('Sorry, there is a problem with the service')
     await expect(this.txtGenericErrorGuidance).toHaveText(
-      'Please contact crn.servicedesk@nihr.ac.uk for further assistance.'
+      'Please contact rdn.servicedesk@nihr.ac.uk for further assistance.'
     )
     await expect(this.page).toHaveURL('500')
   }


### PR DESCRIPTION
update the contact email on error page.
updated tests to use get by test id as the email is now a mailto link and breaks between multiple elements.