### PR TITLE
fix: show user in header on error pages

### DIFF
--- a/apps/web/src/components/organisms/Layout/RootLayout.tsx
+++ b/apps/web/src/components/organisms/Layout/RootLayout.tsx
@@ -37,6 +37,7 @@ export function RootLayout({ children, backLink, heading = SERVICE_NAME, user, b
   const router = useRouter()
   const [sideNavOpen, setSideNavOpen] = useState(false)
   const { data: session } = useSession()
+  const activeUser = user ?? session?.user
   const idle = useIdle(session ? session.idleTimeout * 1000 : undefined)
   const userOrganisations = user?.organisations.filter((userOrg) => !userOrg.isDeleted) ?? []
   const groupIconLink =
@@ -69,7 +70,7 @@ export function RootLayout({ children, backLink, heading = SERVICE_NAME, user, b
     <div className={`${primaryFont.variable} font-sans min-h-screen flex flex-col`}>
       <CookieBanner />
       <SideNav.Provider open={sideNavOpen} setOpen={setSideNavOpen}>
-        <Header heading={heading} user={user} />
+        <Header heading={heading} user={activeUser} />
         {backLink}
         <Breadcrumbs {...breadcrumbConfig} />
         <div className="flex flex-1">


### PR DESCRIPTION
[CRNCC-2410](https://nihr.atlassian.net/browse/CRNCC-2410 )

added a fallback to the root layout, if the user has not been passed in, retrieve the user from the session.