### PR TITLE
Feat/2630 manager contact managers- e2e test update

### DIFF
--- a/apps/web/src/pages/contact-managers/index.tsx
+++ b/apps/web/src/pages/contact-managers/index.tsx
@@ -75,7 +75,7 @@ export default function ContactManager({ contactManagers }: ContactManagerProps)
             <Table.Row key={user.id}>
               <Table.Cell>{user.email}</Table.Cell>
               <Table.Cell>
-                <div className="flex flex-col gap-2 w-fit">{formatDate(user.roles[0].createdAt)}</div>
+                <div className="flex flex-col gap-2 w-fit">{formatDate(user.roles[0].updatedAt)}</div>
               </Table.Cell>
               <Table.Cell>
                 <Link aria-label={`Remove ${user.email}`} href={`/contact-managers/remove-contact-manager/${user.id}`}>

--- a/packages/qa/pages/ContactManagersPage.ts
+++ b/packages/qa/pages/ContactManagersPage.ts
@@ -159,7 +159,7 @@ export default class ContactManagersPage {
     const numberOfContactRows = await this.contactManagersListRow.count()
     for (let index = 0; index < numberOfContactRows; index++) {
       const row = this.contactManagersListRow.nth(index)
-      const expectedDate = convertIsoDateToDisplayDate(expectedDetails[index].createdAt)
+      const expectedDate = convertIsoDateToDisplayDate(expectedDetails[index].updatedAt)
       await expect(row.locator('td').nth(1)).toHaveText(expectedDate)
     }
   }

--- a/packages/qa/tests/features/contactManagerTests/ContactManagersCoreTest.e2e.ts
+++ b/packages/qa/tests/features/contactManagerTests/ContactManagersCoreTest.e2e.ts
@@ -6,7 +6,7 @@ let expectedContactManagerDetails: RowDataPacket[]
 
 test.beforeAll('Setup Test Users', async () => {
   const ContactManagerDetails = await seDatabaseReq(`
-    SELECT User.email, UserRole.createdAt FROM User
+    SELECT User.email, UserRole.updatedAt FROM User
     INNER JOIN UserRole ON User.id = UserRole.userId
     WHERE UserRole.roleID = 2 AND UserRole.isDeleted = 0 AND User.isDeleted = 0
     ORDER BY User.email`)


### PR DESCRIPTION
changed the display to use updated at, records are not fully removed and when a users is re-assigned contact manager the same record is updated.
e2e tests updated to use new field.