### PR TITLE
feat: hiding cheif investigater row for commercial studies

### DIFF
--- a/apps/web/src/__tests__/Study.spec.tsx
+++ b/apps/web/src/__tests__/Study.spec.tsx
@@ -512,7 +512,6 @@ describe('Study', () => {
         'CPMS ID',
         'Sponsor',
         'Managing specialty',
-        'Chief investigator',
       ])
 
       const aboutRows = within(aboutStudyTable).getAllByRole('row')
@@ -523,7 +522,6 @@ describe('Study', () => {
         mockStudy.cpmsId.toString(),
         mockStudy.organisations[0].organisation.name,
         mockStudy.managingSpeciality,
-        `${mockStudy.chiefInvestigatorFirstName} ${mockStudy.chiefInvestigatorLastName}`,
       ])
 
       // Support

--- a/apps/web/src/components/molecules/StudyDetails/StudyDetails.spec.tsx
+++ b/apps/web/src/components/molecules/StudyDetails/StudyDetails.spec.tsx
@@ -127,7 +127,6 @@ describe('StudyDetails Component', () => {
       'CPMS ID',
       'Sponsor',
       'Managing specialty',
-      'Chief investigator',
     ])
 
     const aboutRows = within(table).getAllByRole('row')
@@ -138,7 +137,6 @@ describe('StudyDetails Component', () => {
       '12345',
       'Sponsor Org',
       'Specialty Name',
-      'None available',
     ])
   })
 
@@ -160,5 +158,48 @@ describe('StudyDetails Component', () => {
 
     expect(screen.getByRole('cell', { name: 'CTU Org' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'CRO Org' })).toBeInTheDocument()
+  })
+
+  test('does not render "chief investigator" for commercial studies', () => {
+    const props: StudyDetailsProps = Mock.of<StudyDetailsProps>({
+      study: {
+        title: 'Study Title',
+        protocolReferenceNumber: '123',
+        irasId: null,
+        cpmsId: 12345,
+        organisationsByRole: {
+          Sponsor: 'Sponsor Org',
+        },
+        route: 'Commercial',
+        managingSpeciality: 'Specialty Name',
+        chiefInvestigatorFirstName: null,
+        chiefInvestigatorLastName: null,
+      },
+    })
+
+    render(<StudyDetails {...props} />)
+
+    const table = screen.getByRole('table', { name: 'About this study' })
+    expect(table).toBeInTheDocument()
+
+    const aboutHeaders = within(table).getAllByRole('rowheader')
+    expect(aboutHeaders.map((header) => header.textContent)).toEqual([
+      'Study full title',
+      'Protocol reference number',
+      'IRAS ID',
+      'CPMS ID',
+      'Sponsor',
+      'Managing specialty',
+    ])
+
+    const aboutRows = within(table).getAllByRole('row')
+    expect(aboutRows.map((row) => within(row).getByRole('cell').textContent)).toEqual([
+      'Study Title',
+      '123',
+      'None available',
+      '12345',
+      'Sponsor Org',
+      'Specialty Name',
+    ])
   })
 })

--- a/apps/web/src/components/molecules/StudyDetails/StudyDetails.tsx
+++ b/apps/web/src/components/molecules/StudyDetails/StudyDetails.tsx
@@ -59,14 +59,16 @@ export function StudyDetails({ study }: StudyDetailsProps) {
           <Table.Cell>{study.managingSpeciality}</Table.Cell>
         </Table.Row>
 
-        <Table.Row>
-          <Table.CellHeader className="w-1/3">Chief investigator</Table.CellHeader>
-          <Table.Cell>
-            {study.chiefInvestigatorFirstName
-              ? `${study.chiefInvestigatorFirstName} ${study.chiefInvestigatorLastName}`
-              : 'None available'}
-          </Table.Cell>
-        </Table.Row>
+        {study.route !== 'Commercial' && (
+          <Table.Row>
+            <Table.CellHeader className="w-1/3">Chief investigator</Table.CellHeader>
+            <Table.Cell>
+              {study.chiefInvestigatorFirstName
+                ? `${study.chiefInvestigatorFirstName} ${study.chiefInvestigatorLastName}`
+                : 'None available'}
+            </Table.Cell>
+          </Table.Row>
+        )}
       </Table.Body>
     </Table>
   )


### PR DESCRIPTION
https://nihr.atlassian.net/browse/CRNCC-2026

added conditional to the chief investigator role in the study details to hide the chief investigator if study route is commercial.
updated tests.