### PR TITLE
Fix/CRNCC-2873 accessibility report fixes

### DIFF
--- a/apps/web/src/__tests__/Organisations.spec.tsx
+++ b/apps/web/src/__tests__/Organisations.spec.tsx
@@ -137,9 +137,9 @@ describe('Organisations page', () => {
     // This looks funny because the formatting that GDS visually-hidden applies is stripped out
     expect(rows.map((row) => row.firstChild?.textContent)).toEqual([
       'Organisation',
-      'Organisation name:Org name 1Organisation role:Sponsor',
-      'Organisation name:Org name 2Organisation role:CRO',
-      'Organisation name:Org name 3Organisation role:CTU',
+      'Org name 1 - organisation nameSponsor - organisation role',
+      'Org name 2 - organisation nameCRO - organisation role',
+      'Org name 3 - organisation nameCTU - organisation role',
     ])
 
     expect(rows.map((row) => row.lastChild?.textContent)).toEqual([
@@ -255,7 +255,7 @@ describe('Organisations page', () => {
     const table = within(screen.getByRole('table', { name: 'Manage sponsor organisations' }))
     expect(
       table.getByRole('row', {
-        name: 'Organisation name: Test Org Organisation role: Sponsor, CTU Manage Test Org sponsor contacts',
+        name: 'Test Org - organisation name Sponsor, CTU - organisation role Manage Test Org sponsor contacts',
       })
     ).toBeInTheDocument()
   })

--- a/apps/web/src/components/organisms/Layout/RootLayout.tsx
+++ b/apps/web/src/components/organisms/Layout/RootLayout.tsx
@@ -71,8 +71,6 @@ export function RootLayout({ children, backLink, heading = SERVICE_NAME, user, b
       <CookieBanner />
       <SideNav.Provider open={sideNavOpen} setOpen={setSideNavOpen}>
         <Header heading={heading} user={activeUser} />
-        {backLink}
-        <Breadcrumbs {...breadcrumbConfig} />
         <div className="flex flex-1">
           <SideNav.Panel className="flex flex-col" data-testid="side-panel">
             <SideNav.Link as={Link} href="/" icon={<HomeIcon />}>
@@ -94,7 +92,13 @@ export function RootLayout({ children, backLink, heading = SERVICE_NAME, user, b
               </SideNav.Link>
             ) : null}
           </SideNav.Panel>
-          <SideNav.Main className="flex-1 overflow-auto">{children}</SideNav.Main>
+          <SideNav.Main className="flex-1 overflow-auto">
+            <div className="-mt-2 govuk-!-margin-bottom-4">
+              {backLink}
+              <Breadcrumbs {...breadcrumbConfig} />
+            </div>
+            {children}
+          </SideNav.Main>
         </div>
         <Footer />
       </SideNav.Provider>

--- a/apps/web/src/pages/organisations/index.tsx
+++ b/apps/web/src/pages/organisations/index.tsx
@@ -81,12 +81,12 @@ export default function Organisations({
                           <Table.Row key={id}>
                             <Table.Cell>
                               <Link href={`/organisations/${id}`}>
-                                <span className="govuk-visually-hidden">Organisation name:</span>
                                 <strong>{name}</strong>
+                                <span className="govuk-visually-hidden"> - organisation name</span>
                               </Link>
                               <div className="govuk-body-s mb-0 govuk-!-margin-top-1">
-                                <span className="govuk-visually-hidden">Organisation role:</span>
                                 {roles.map((role) => role).join(', ')}
+                                <span className="govuk-visually-hidden"> - organisation role</span>
                               </div>
                             </Table.Cell>
                             <Table.Cell className="align-middle text-right">

--- a/packages/ui/components/Icons/GroupIcon.tsx
+++ b/packages/ui/components/Icons/GroupIcon.tsx
@@ -11,6 +11,8 @@ export const GroupIcon = ({ className }: GroupIconProps) => {
       viewBox="0 -960 960 960"
       className={`${className} h-[1.5em] w-[1.5em]`}
       fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
       data-testid="group-icon"
     >
       <path d="M40-160v-112q0-34 17.5-62.5T104-378q62-31 126-46.5T360-440q66 0 130 15.5T616-378q29 15 46.5 43.5T680-272v112H40Zm720 0v-120q0-44-24.5-84.5T666-434q51 6 96 20.5t84 35.5q36 20 55 44.5t19 53.5v120H760ZM360-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm400-160q0 66-47 113t-113 47q-11 0-28-2.5t-28-5.5q27-32 41.5-71t14.5-81q0-42-14.5-81T544-792q14-5 28-6.5t28-1.5q66 0 113 47t47 113Z" />

--- a/packages/ui/components/Icons/HomeIcon.tsx
+++ b/packages/ui/components/Icons/HomeIcon.tsx
@@ -6,6 +6,7 @@ export const HomeIcon = () => (
     viewBox="0 0 20 17"
     fill="currentColor"
     aria-hidden="true"
+    focusable="false"
     className="h-[21px] w-[21px]"
     data-testid="home-icon"
   >

--- a/packages/ui/components/Icons/SettingsIcon.tsx
+++ b/packages/ui/components/Icons/SettingsIcon.tsx
@@ -2,6 +2,7 @@ export const SettingsIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     aria-hidden="true"
+    focusable="false"
     fill="currentColor"
     className="h-[20px] w-[20px]"
     data-testid="settings-icon"

--- a/packages/ui/components/Icons/__snapshots__/Icons.spec.tsx.snap
+++ b/packages/ui/components/Icons/__snapshots__/Icons.spec.tsx.snap
@@ -54,9 +54,11 @@ exports[`NIHR Icon Set Displays the "GroupIcon" correctly 1`] = `
 <body>
   <div>
     <svg
+      aria-hidden="true"
       class="undefined h-[1.5em] w-[1.5em]"
       data-testid="group-icon"
       fill="currentColor"
+      focusable="false"
       viewBox="0 -960 960 960"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -76,6 +78,7 @@ exports[`NIHR Icon Set Displays the "HomeIcon" correctly 1`] = `
       class="h-[21px] w-[21px]"
       data-testid="home-icon"
       fill="currentColor"
+      focusable="false"
       height="17"
       viewBox="0 0 20 17"
       width="20"
@@ -112,6 +115,7 @@ exports[`NIHR Icon Set Displays the "SettingsIcon" correctly 1`] = `
       class="h-[20px] w-[20px]"
       data-testid="settings-icon"
       fill="currentColor"
+      focusable="false"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/ui/globals.scss
+++ b/packages/ui/globals.scss
@@ -147,3 +147,35 @@ body {
   width: 100%;
   z-index: 9999;
 }
+
+// Forced colours in high contrast mode
+@media (forced-colors: active) {
+  :root {
+    --text-grey: CanvasText;
+    --header-bg: Canvas;
+  }
+  html, body { color: CanvasText !important; background: Canvas !important; }
+  a { color: LinkText !important; text-decoration: underline; }
+  svg { fill: currentColor !important; stroke: currentColor !important; }
+
+
+button .absolute.h-\[2px\].w-\[18px\] {
+    background: CanvasText !important;
+  }
+  button .absolute.h-\[2px\].w-\[18px\]::before,
+  button .absolute.h-\[2px\].w-\[18px\]::after {
+    background: CanvasText !important;
+  }
+
+  button[aria-controls="nihr-side-nav"] {
+    background: transparent;
+    color: CanvasText; 
+  }
+
+  button[aria-controls="nihr-side-nav"]:focus {
+    outline: 2px solid CanvasText !important;
+    outline-offset: 2px !important;
+    box-shadow: none !important;
+    background-image: none !important;
+  }
+}


### PR DESCRIPTION
Fixing issues found in the accessibility report found here: https://drive.google.com/file/d/1BoN0pGZgEIQoPXQ_Iq_bamzQG1C_7tYq/view?pli=1

- Missing Alt Text
  - Ensured that all svg images used purely for decoration purposes have a blank alternative text attribute

- STAS-F02: Visible Label and Accessible
  - Updated the accessible labels to ensure they start with the visible label 
 
- STAS-F03: Illogical Tab Order
  - Updated elements on the root layout to alter the tab order
 
- STAS-F04: Colours Preference Overwrite
  - Tested and ensured that the header colours can be overridden. Updated the side nav button to ensure it can change colour when increased contrast is applied