### PR TITLE
fix: remove sponsor contact role when no longer assigned to any org

### DIFF
--- a/apps/web/src/pages/api/forms/organisation.spec.ts
+++ b/apps/web/src/pages/api/forms/organisation.spec.ts
@@ -96,6 +96,7 @@ describe('Successful organisation sponsor contact invitation', () => {
       registrationConfirmed: false,
       isDeleted: false,
       lastLogin: null,
+      roles: [],
     }
 
     const messageId = '121'
@@ -260,6 +261,7 @@ describe('Successful organisation sponsor contact invitation', () => {
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
+      roles: [],
     }
 
     const messageId = '121'
@@ -423,6 +425,7 @@ describe('Successful organisation sponsor contact invitation', () => {
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
+      roles: [],
     }
 
     const messageId = '121'

--- a/apps/web/src/pages/api/forms/organisation.spec.ts
+++ b/apps/web/src/pages/api/forms/organisation.spec.ts
@@ -208,22 +208,17 @@ describe('Successful organisation sponsor contact invitation', () => {
     })
 
     // First update call (token)
-    expect(prismaClient.user.update).toHaveBeenNthCalledWith(1, {
-      where: { email: body.emailAddress },
-      data: {
-        registrationToken: 'mocked-token',
-        registrationConfirmed: false,
+    expect(prismaClient.user.update).toHaveBeenCalledWith({
+      where: {
+        email: body.emailAddress,
       },
-    })
-
-    // Second update call (role)
-    expect(prismaClient.user.update).toHaveBeenNthCalledWith(2, {
-      where: { email: body.emailAddress },
       data: {
+        registrationConfirmed: false,
+        registrationToken,
         roles: {
           createMany: {
             data: {
-              roleId: 999,
+              roleId: findSysRefRoleResponse.id,
               createdById: userWithContactManagerRole.user?.id,
               updatedById: userWithContactManagerRole.user?.id,
             },
@@ -315,9 +310,7 @@ describe('Successful organisation sponsor contact invitation', () => {
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
-      roles: [],
     })
-
 
     const messageId = '121'
     jest.mocked(emailService.sendEmail).mockResolvedValue({
@@ -390,9 +383,7 @@ describe('Successful organisation sponsor contact invitation', () => {
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
-      roles: [],
     })
-
 
     const messageId = '121'
 

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -142,8 +142,8 @@ export default withApiHandler<ExtendedNextApiRequest>(
 
       const userOrganisationId = users[0].id
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison,@typescript-eslint/no-unnecessary-condition -- false positive and nullable is needed
       const isPreviousSponsorContact =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison,@typescript-eslint/no-unnecessary-condition -- false positive and nullable is needed
         existingUser && existingUser.roles?.find((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
 
       if (isPreviousSponsorContact) {

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -143,8 +143,8 @@ export default withApiHandler<ExtendedNextApiRequest>(
       const userOrganisationId = users[0].id
 
       const isPreviousSponsorContact =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison,@typescript-eslint/no-unnecessary-condition -- false positive and nullable is needed
-        existingUser && existingUser.roles?.some((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- false positive and nullable is needed
+        existingUser && existingUser.roles.some((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
 
       if (isPreviousSponsorContact) {
         logger.info(`Re-adding sponsor contact role for ${existingUser.email}`)

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -143,8 +143,8 @@ export default withApiHandler<ExtendedNextApiRequest>(
       const userOrganisationId = users[0].id
 
       const isPreviousSponsorContact =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- false positive and nullable is needed
-        existingUser && existingUser.roles.some((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
+        existingUser &&
+        existingUser.roles.some((x) => x.roleId === Roles.SponsorContact.valueOf() && x.isDeleted === true)
 
       if (isPreviousSponsorContact) {
         logger.info(`Re-adding sponsor contact role for ${existingUser.email}`)

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -144,7 +144,7 @@ export default withApiHandler<ExtendedNextApiRequest>(
 
       const isPreviousSponsorContact =
         // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison,@typescript-eslint/no-unnecessary-condition -- false positive and nullable is needed
-        existingUser && existingUser.roles?.find((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
+        existingUser && existingUser.roles?.some((x) => x.roleId === Roles.SponsorContact && x.isDeleted === true)
 
       if (isPreviousSponsorContact) {
         logger.info(`Re-adding sponsor contact role for ${existingUser.email}`)
@@ -162,7 +162,6 @@ export default withApiHandler<ExtendedNextApiRequest>(
               },
               data: {
                 updatedById: requestedByUserId,
-                createdById: requestedByUserId,
                 isDeleted: false,
               },
             },

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -142,8 +142,6 @@ export default withApiHandler<ExtendedNextApiRequest>(
         },
       })
 
-      const shouldUpdateRegistrationToken = (existingUser?.identityGatewayId ?? null) === null
-
       // Add user to organisation
       const { name: organisationName, users } = await prismaClient.organisation.update({
         where: {
@@ -190,7 +188,6 @@ export default withApiHandler<ExtendedNextApiRequest>(
 
       const userOrganisationId = users[0].id
 
-
       const isPreviousSponsorContact =
         existingUser &&
         existingUser.roles.some((x) => x.roleId === Roles.SponsorContact.valueOf() && x.isDeleted === true)
@@ -198,12 +195,11 @@ export default withApiHandler<ExtendedNextApiRequest>(
       if (isPreviousSponsorContact) {
         logger.info(`Re-adding sponsor contact role for ${existingUser.email}`)
       }
-      
-       let registrationToken: string | null = null
+
+      let registrationToken: string | null = null
       if (isNewToIDG) {
         registrationToken = crypto.randomBytes(24).toString('hex')
       }
-
 
       const roleMutation = isPreviousSponsorContact
         ? {

--- a/apps/web/src/pages/api/forms/removeContact.ts
+++ b/apps/web/src/pages/api/forms/removeContact.ts
@@ -87,14 +87,13 @@ export default withApiHandler<ExtendedNextApiRequest>(
         await removeUserFromGroup(user.email, ODP_ROLE_GROUP_ID)
       }
       // check if user contact for any other orgs and remove role if there is none.
-      const otherOrganisation = await prismaClient.userOrganisation.findMany({
+      const otherOrganisation = await prismaClient.userOrganisation.findFirst({
         where: {
           userId: user.id,
           isDeleted: false,
         },
       })
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- condition is being flagged as always falsy
       if (!otherOrganisation) {
         logger.info(
           'User is no longer a sponsor contact for any organisation, removing Sponser contact role for %s',

--- a/apps/web/src/pages/api/forms/removeContact.ts
+++ b/apps/web/src/pages/api/forms/removeContact.ts
@@ -87,14 +87,15 @@ export default withApiHandler<ExtendedNextApiRequest>(
         await removeUserFromGroup(user.email, ODP_ROLE_GROUP_ID)
       }
       // check if user contact for any other orgs and remove role if there is none.
-      const otherOrganisation = await prismaClient.userOrganisation.findFirst({
+      const hasActiveOrganisation = await prismaClient.userOrganisation.findFirst({
         where: {
           userId: user.id,
           isDeleted: false,
         },
+        select: { id: true },
       })
 
-      if (!otherOrganisation) {
+      if (!hasActiveOrganisation) {
         logger.info(
           'User is no longer a sponsor contact for any organisation, removing Sponser contact role for %s',
           user.email

--- a/packages/database/prisma/migrations/20260224142643_crncc_2681_sponsor_contact_role/migration.sql
+++ b/packages/database/prisma/migrations/20260224142643_crncc_2681_sponsor_contact_role/migration.sql
@@ -1,0 +1,14 @@
+-- remove the sponsor contact role for users not a sponsor contact for any org
+
+UPDATE `sponsorengagement`.`UserRole` ur 
+SET 
+    ur.isDeleted = 1
+WHERE
+    ur.roleId = 1 and ur.userId NOT IN ( SELECT 
+            uo.userId
+        FROM
+            UserOrganisation uo 
+        WHERE
+			uo.isDeleted = 0
+        GROUP BY uo.userId
+        )


### PR DESCRIPTION
Ticket 
https://nihr.atlassian.net/browse/CRNCC-2681.

remove the sponsor contact role when the user is removed from a org and is not part of another org.
re-activate sponsor contact role when being added to a org when user was previously a sponsor contact but is no longer.