### PR TITLE
Revert "fix: CRNCC-2964 fixing issue where IDG role was not set for existing accounts"

### DIFF
--- a/apps/web/src/pages/api/forms/organisation.spec.ts
+++ b/apps/web/src/pages/api/forms/organisation.spec.ts
@@ -1,19 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment -- mock objects in tests do not conform to strict typing */
-import { authService } from '@nihr-ui/auth'
 import { emailService } from '@nihr-ui/email'
 import { logger } from '@nihr-ui/logger'
-import type { SysRefInvitationStatus, SysRefOrganisationRole, UserOrganisationInvitation } from 'database'
+import type {
+  Assessment,
+  Study,
+  SysRefInvitationStatus,
+  SysRefOrganisationRole,
+  UserOrganisationInvitation,
+} from 'database'
 import type { NextApiResponse } from 'next'
 import { getServerSession } from 'next-auth'
 import type { RequestOptions } from 'node-mocks-http'
 import { createRequest, createResponse } from 'node-mocks-http'
 import { Mock } from 'ts-mockery'
+import { ZodError } from 'zod'
 
 import { userNoRoles, userWithContactManagerRole } from '@/__mocks__/session'
 import { EXTERNAL_CRN_TERMS_CONDITIONS_URL, EXTERNAL_CRN_URL, SIGN_IN_PAGE, SUPPORT_PAGE } from '@/constants/routes'
 import type { OrganisationWithRelations, UserOrganisationWithRelations } from '@/lib/organisations'
-import { getOrganisationById } from '@/lib/organisations'
 import { prismaClient } from '@/lib/prisma'
+import { AuthError } from '@/utils/auth'
 import type { OrganisationAddInputs } from '@/utils/schemas'
 
 import type { ExtendedNextApiRequest } from './organisation'
@@ -22,9 +27,6 @@ import api from './organisation'
 jest.mock('next-auth/next')
 jest.mock('@nihr-ui/logger')
 jest.mock('@nihr-ui/email')
-jest.mock('@nihr-ui/auth')
-jest.mock('@/lib/organisations')
-
 jest.mock('node:crypto', () => ({
   randomBytes: () => 'mocked-token',
 }))
@@ -49,20 +51,12 @@ const findSysRefInvitationStatusResponse = Mock.of<SysRefInvitationStatus>({
   name: 'Pending',
 })
 
-const findOrgResponse = Mock.of<OrganisationWithRelations>({
-  id: 2,
-  name: 'Test Organisation',
-  roles: [],
-})
+const findOrgResponse = Mock.of<OrganisationWithRelations>({ id: 2, name: 'Test Organisation', roles: [] })
 
 const currentDate = new Date('2025-03-31')
 
-/* -------------------------------------------------------------------------- */
-/* SUCCESS CASES                                                              */
-/* -------------------------------------------------------------------------- */
-
 describe('Successful organisation sponsor contact invitation', () => {
-  const registrationToken = 'mocked-token'
+  const registrationToken = 'mock-token'
 
   const body: OrganisationAddInputs = {
     organisationId: '321',
@@ -72,66 +66,29 @@ describe('Successful organisation sponsor contact invitation', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.mocked(getServerSession).mockResolvedValueOnce(userWithContactManagerRole)
-
-    // Correct organisation lookup (handler uses this)
-    jest.mocked(getOrganisationById).mockResolvedValue(findOrgResponse)
-
-    // Correct Zod-shaped IDG response
-    const idgResponse: Awaited<ReturnType<typeof authService.getUser>> = {
-      success: true,
-      data: {
-        totalResults: 0,
-        startIndex: 0,
-        itemsPerPage: 0,
-        schemas: [],
-        Resources: [],
-      },
-    }
-
-    jest.mocked(authService.getUser).mockResolvedValue(idgResponse)
-
-    // Correct Prisma User return
-    const prismaUser = {
-      id: 2,
-      name: null,
-      email: body.emailAddress,
-      identityGatewayId: null,
-      registrationToken: null,
-      registrationConfirmed: false,
-      isDeleted: false,
-      lastLogin: null,
-    }
-
-    jest.mocked(prismaClient.user.upsert).mockResolvedValue(prismaUser)
-    jest.mocked(prismaClient.user.findUniqueOrThrow).mockResolvedValue(prismaUser)
-
     logger.info = jest.fn()
   })
 
-  /* ------------------------------ NEW USER -------------------------------- */
-
   test('New user', async () => {
     jest.useFakeTimers().setSystemTime(currentDate)
-
     const updateOrgResponse = Mock.of<OrganisationWithRelations>({
       id: 2,
       roles: [],
       name: 'Mock org name',
       users: [
         {
-          id: 555,
           user: {
-            id: 2,
             email: body.emailAddress,
             registrationConfirmed: false,
             registrationToken,
+            id: 2,
           },
         },
       ],
     })
 
-    const updatedUser = {
-      id: 2,
+    const updateUserResponse = {
+      id: 1,
       name: null,
       email: body.emailAddress,
       identityGatewayId: null,
@@ -143,86 +100,86 @@ describe('Successful organisation sponsor contact invitation', () => {
 
     const messageId = '121'
 
-    // Correct invitation mock
-    const invitation: UserOrganisationInvitation = {
+    const createUserOrgInvitation = Mock.of<UserOrganisationInvitation>({
       id: 1,
-      userOrganisationId: 555,
+      userOrganisationId: updateOrgResponse.users[0].id,
       messageId,
       timestamp: currentDate,
-      statusId: 121,
+      statusId: findSysRefInvitationStatusResponse.id,
       failureNotifiedAt: null,
       createdAt: currentDate,
       updatedAt: currentDate,
-      sentById: userWithContactManagerRole.user?.id ?? 1,
-      isDeleted: false,
-    }
-
-    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValueOnce(null)
-
-    jest.mocked(prismaClient.sysRefRole.findFirstOrThrow).mockResolvedValue(findSysRefRoleResponse)
-
-    const updateOrgMock = jest.mocked(prismaClient.organisation.update).mockResolvedValue(updateOrgResponse)
-
-    // Two update calls: token then role
-    jest.mocked(prismaClient.user.update).mockResolvedValue(updatedUser)
-    jest.mocked(prismaClient.user.update).mockResolvedValue(updatedUser)
-
-    jest.mocked(emailService.sendEmail).mockResolvedValue({
-      messageId,
-      recipients: [],
     })
 
+    jest.mocked(prismaClient.organisation.findFirst).mockResolvedValueOnce(findOrgResponse)
+
+    const findSysRefRoleMock = jest
+      .mocked(prismaClient.sysRefRole.findFirstOrThrow)
+      .mockResolvedValueOnce(findSysRefRoleResponse)
+    const updateOrgMock = jest.mocked(prismaClient.organisation.update).mockResolvedValueOnce(updateOrgResponse)
+
+    jest.mocked(prismaClient.user.update).mockResolvedValueOnce(updateUserResponse)
+
+    jest.mocked(emailService.sendEmail).mockResolvedValueOnce({ messageId, recipients: [] })
     jest
       .mocked(prismaClient.sysRefInvitationStatus.findFirstOrThrow)
-      .mockResolvedValue(findSysRefInvitationStatusResponse)
+      .mockResolvedValueOnce(findSysRefInvitationStatusResponse)
 
-    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValue(invitation)
+    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValueOnce(createUserOrgInvitation)
 
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
-    })
+    const res = await testHandler(api, { method: 'POST', body })
 
+    expect(findSysRefRoleMock).toHaveBeenCalledWith({ where: { isDeleted: false, name: 'SponsorContact' } })
+
+    // Org is updated
     expect(updateOrgMock).toHaveBeenCalledWith({
       where: { id: Number(body.organisationId) },
       include: {
         users: {
-          where: { user: { email: body.emailAddress } },
-          select: { id: true, user: true },
+          select: {
+            id: true,
+            user: true,
+          },
+          where: {
+            user: {
+              email: body.emailAddress,
+            },
+          },
         },
       },
       data: {
         users: {
           create: {
-            createdBy: {
-              connect: { id: userWithContactManagerRole.user?.id },
+            createdBy: { connect: { id: userWithContactManagerRole.user?.id } },
+            updatedBy: { connect: { id: userWithContactManagerRole.user?.id } },
+            user: {
+              connectOrCreate: {
+                create: {
+                  email: body.emailAddress,
+                },
+                where: {
+                  email: body.emailAddress,
+                },
+              },
             },
-            updatedBy: {
-              connect: { id: userWithContactManagerRole.user?.id },
-            },
-            user: { connect: { email: body.emailAddress } },
           },
         },
       },
     })
 
-    // First update call (token)
-    expect(prismaClient.user.update).toHaveBeenNthCalledWith(1, {
-      where: { email: body.emailAddress },
-      data: {
-        registrationToken: 'mocked-token',
-        registrationConfirmed: false,
+    // User role is added
+    expect(prismaClient.user.update).toHaveBeenCalledWith({
+      where: {
+        email: body.emailAddress,
       },
-    })
-
-    // Second update call (role)
-    expect(prismaClient.user.update).toHaveBeenNthCalledWith(2, {
-      where: { email: body.emailAddress },
       data: {
+        registrationConfirmed: false,
+        registrationToken: 'mocked-token',
         roles: {
+          // If a user is not assigned the sponsor contact role, assign it
           createMany: {
             data: {
-              roleId: 999,
+              roleId: findSysRefRoleResponse.id,
               createdById: userWithContactManagerRole.user?.id,
               updatedById: userWithContactManagerRole.user?.id,
             },
@@ -232,203 +189,357 @@ describe('Successful organisation sponsor contact invitation', () => {
       },
     })
 
+    // Send email
     expect(emailService.sendEmail).toHaveBeenCalledWith({
-      to: body.emailAddress,
       subject: 'Assess the progress of your studies',
-      htmlTemplate: expect.any(Function),
-      textTemplate: expect.any(Function),
       templateData: {
-        organisationName: updateOrgResponse.name,
         rdnLink: EXTERNAL_CRN_URL,
+        organisationName: updateOrgResponse.name,
         requestSupportLink: `http://localhost:3000${SUPPORT_PAGE}`,
         signInLink: `http://localhost:3000/auth/signin?registrationToken=${registrationToken}`,
         termsAndConditionsLink: EXTERNAL_CRN_TERMS_CONDITIONS_URL,
       },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      htmlTemplate: expect.any(Function),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      textTemplate: expect.any(Function),
+      to: body.emailAddress,
     })
 
-    expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}?success=1`)
-  })
+    // Entry in UserOrganisationInvitation table is added
+    expect(prismaClient.userOrganisationInvitation.create).toHaveBeenCalledWith({
+      data: {
+        messageId,
+        timestamp: createUserOrgInvitation.timestamp,
+        status: {
+          connect: {
+            id: createUserOrgInvitation.statusId,
+          },
+        },
+        userOrganisation: {
+          connect: {
+            id: createUserOrgInvitation.userOrganisationId,
+          },
+        },
+        sentBy: { connect: { id: userWithContactManagerRole.user?.id } },
+      },
+    })
 
-  /* -------------------- EXISTING CONFIRMED USER -------------------- */
+    // Redirect back to organisation page
+    expect(res.statusCode).toBe(302)
+    expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}?success=1`)
+
+    jest.useRealTimers()
+  })
 
   test('Existing user - registration confirmed', async () => {
     jest.useFakeTimers().setSystemTime(currentDate)
 
-    jest.mocked(authService.getUser).mockResolvedValue({
-      success: true,
-      data: {
-        totalResults: 1,
-        startIndex: 1,
-        itemsPerPage: 1,
-        schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
-        Resources: [
-          {
-            id: 'idg-123',
-            userName: 'idg-123',
-            groups: [],
-          },
-        ],
-      },
-    })
-
-    jest.mocked(prismaClient.user.findUniqueOrThrow).mockResolvedValue({
-      id: 2,
-      name: null,
-      email: body.emailAddress,
-      identityGatewayId: 'idg-123',
-      registrationToken: null,
-      registrationConfirmed: true,
-      isDeleted: false,
-      lastLogin: null,
-    })
-
     const updateOrgResponse = Mock.of<OrganisationWithRelations>({
       id: 2,
-      name: 'Mock org name',
       roles: [],
+      name: 'Mock org name',
       users: [
         {
-          id: 444,
           user: {
             id: 2,
             email: body.emailAddress,
-            registrationConfirmed: true,
+            registrationConfirmed: false,
             registrationToken: null,
           },
         },
       ],
     })
 
-    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValue(null)
-
-    jest.mocked(prismaClient.sysRefRole.findFirstOrThrow).mockResolvedValue(findSysRefRoleResponse)
-
-    jest.mocked(prismaClient.organisation.update).mockResolvedValue(updateOrgResponse)
-
-    jest.mocked(prismaClient.user.update).mockResolvedValue({
-      id: 2,
+    const updateUserResponse = {
+      id: 1,
       name: null,
       email: body.emailAddress,
-      identityGatewayId: 'idg-123',
+      identityGatewayId: 'mock-gateway-id',
       registrationToken: null,
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
-    })
+    }
 
     const messageId = '121'
-    jest.mocked(emailService.sendEmail).mockResolvedValue({
-      messageId,
-      recipients: [],
-    })
 
-    jest
-      .mocked(prismaClient.sysRefInvitationStatus.findFirstOrThrow)
-      .mockResolvedValue(findSysRefInvitationStatusResponse)
-
-    const invitation: UserOrganisationInvitation = {
+    const createUserOrgInvitation = Mock.of<UserOrganisationInvitation>({
       id: 1,
-      userOrganisationId: 444,
+      userOrganisationId: updateOrgResponse.users[0].id,
       messageId,
       timestamp: currentDate,
-      statusId: 121,
+      statusId: findSysRefInvitationStatusResponse.id,
       failureNotifiedAt: null,
       createdAt: currentDate,
       updatedAt: currentDate,
-      sentById: userWithContactManagerRole.user?.id ?? 1,
-      isDeleted: false,
-    }
-
-    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValue(invitation)
-
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
     })
 
-    expect(emailService.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        templateData: expect.objectContaining({
-          signInLink: 'http://localhost:3000/auth/signin',
-        }),
-      })
-    )
+    jest.mocked(prismaClient.user.findUnique).mockResolvedValueOnce(updateUserResponse)
+    jest.mocked(prismaClient.organisation.findFirst).mockResolvedValueOnce(findOrgResponse)
+    jest.mocked(prismaClient.user.update).mockResolvedValueOnce(updateUserResponse)
+    jest.mocked(emailService.sendEmail).mockResolvedValueOnce({ messageId, recipients: [] })
+    jest
+      .mocked(prismaClient.sysRefInvitationStatus.findFirstOrThrow)
+      .mockResolvedValueOnce(findSysRefInvitationStatusResponse)
 
+    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValueOnce(createUserOrgInvitation)
+
+    const findSysRefRoleMock = jest
+      .mocked(prismaClient.sysRefRole.findFirstOrThrow)
+      .mockResolvedValueOnce(findSysRefRoleResponse)
+    const updateOrgMock = jest.mocked(prismaClient.organisation.update).mockResolvedValueOnce(updateOrgResponse)
+
+    const res = await testHandler(api, { method: 'POST', body })
+
+    expect(findSysRefRoleMock).toHaveBeenCalledWith({ where: { isDeleted: false, name: 'SponsorContact' } })
+
+    // Org is updated
+    expect(updateOrgMock).toHaveBeenCalledWith({
+      where: { id: Number(body.organisationId) },
+      include: {
+        users: {
+          select: {
+            id: true,
+            user: true,
+          },
+          where: {
+            user: {
+              email: body.emailAddress,
+            },
+          },
+        },
+      },
+      data: {
+        users: {
+          create: {
+            createdBy: { connect: { id: userWithContactManagerRole.user?.id } },
+            updatedBy: { connect: { id: userWithContactManagerRole.user?.id } },
+            user: {
+              connectOrCreate: {
+                create: {
+                  email: body.emailAddress,
+                },
+                where: {
+                  email: body.emailAddress,
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // User role is added
+    expect(prismaClient.user.update).toHaveBeenCalledWith({
+      where: {
+        email: body.emailAddress,
+      },
+      data: {
+        roles: {
+          // If a user is not assigned the sponsor contact role, assign it
+          createMany: {
+            data: {
+              roleId: findSysRefRoleResponse.id,
+              createdById: userWithContactManagerRole.user?.id,
+              updatedById: userWithContactManagerRole.user?.id,
+            },
+            skipDuplicates: true,
+          },
+        },
+      },
+    })
+
+    // Send email
+    expect(emailService.sendEmail).toHaveBeenCalledWith({
+      subject: 'Assess the progress of your studies',
+      templateData: {
+        rdnLink: EXTERNAL_CRN_URL,
+        organisationName: updateOrgResponse.name,
+        requestSupportLink: `http://localhost:3000${SUPPORT_PAGE}`,
+        signInLink: 'http://localhost:3000/auth/signin',
+        termsAndConditionsLink: EXTERNAL_CRN_TERMS_CONDITIONS_URL,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      htmlTemplate: expect.any(Function),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      textTemplate: expect.any(Function),
+      to: body.emailAddress,
+    })
+
+    // Entry in UserOrganisationInvitation table is added
+    expect(prismaClient.userOrganisationInvitation.create).toHaveBeenCalledWith({
+      data: {
+        messageId,
+        timestamp: createUserOrgInvitation.timestamp,
+        status: {
+          connect: {
+            id: createUserOrgInvitation.statusId,
+          },
+        },
+        userOrganisation: {
+          connect: {
+            id: createUserOrgInvitation.userOrganisationId,
+          },
+        },
+        sentBy: {
+          connect: {
+            id: userWithContactManagerRole.user?.id,
+          },
+        },
+      },
+    })
+
+    // Redirect back to organisation page
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}?success=1`)
-  })
 
-  /* ------------------------ RE-ACTIVATE USER ----------------------- */
+    jest.useRealTimers()
+  })
 
   test('Re-add deleted contact', async () => {
     jest.useFakeTimers().setSystemTime(currentDate)
-
-    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValue({
-      id: 123,
-      isDeleted: true,
-    } as UserOrganisationWithRelations)
-
-    jest.mocked(prismaClient.sysRefRole.findFirstOrThrow).mockResolvedValue(findSysRefRoleResponse)
-
     const updateOrgResponse = Mock.of<OrganisationWithRelations>({
       id: 2,
-      name: 'Mock org name',
       roles: [],
-      users: [{ id: 123, user: { email: body.emailAddress } }],
+      name: 'Mock org name',
+      users: [
+        {
+          user: {
+            email: body.emailAddress,
+            registrationConfirmed: false,
+            registrationToken: null,
+          },
+        },
+      ],
     })
 
-    jest.mocked(prismaClient.organisation.update).mockResolvedValue(updateOrgResponse)
-
-    jest.mocked(prismaClient.user.update).mockResolvedValue({
-      id: 2,
+    const updateUserResponse = {
+      id: 1,
       name: null,
       email: body.emailAddress,
-      identityGatewayId: null,
+      identityGatewayId: 'mock-gateway-id',
       registrationToken: null,
       registrationConfirmed: true,
       isDeleted: false,
       lastLogin: null,
-    })
+    }
 
     const messageId = '121'
 
-    jest.mocked(emailService.sendEmail).mockResolvedValue({
-      messageId,
-      recipients: [],
-    })
-
-    jest
-      .mocked(prismaClient.sysRefInvitationStatus.findFirstOrThrow)
-      .mockResolvedValue(findSysRefInvitationStatusResponse)
-
-    const invitation: UserOrganisationInvitation = {
+    const createUserOrgInvitation = Mock.of<UserOrganisationInvitation>({
       id: 1,
-      userOrganisationId: 123,
+      userOrganisationId: updateOrgResponse.users[0].id,
       messageId,
       timestamp: currentDate,
-      statusId: 121,
+      statusId: findSysRefInvitationStatusResponse.id,
       failureNotifiedAt: null,
       createdAt: currentDate,
       updatedAt: currentDate,
-      sentById: userWithContactManagerRole.user?.id ?? 1,
-      isDeleted: false,
-    }
-
-    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValue(invitation)
-
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
     })
 
-    expect(emailService.sendEmail).toHaveBeenCalled()
+    jest.mocked(prismaClient.user.findUnique).mockResolvedValueOnce(updateUserResponse)
+    jest.mocked(prismaClient.user.update).mockResolvedValueOnce(updateUserResponse)
+    jest.mocked(prismaClient.organisation.findFirst).mockResolvedValueOnce(findOrgResponse)
+    jest.mocked(emailService.sendEmail).mockResolvedValueOnce({ messageId, recipients: [] })
+    jest
+      .mocked(prismaClient.sysRefInvitationStatus.findFirstOrThrow)
+      .mockResolvedValueOnce(findSysRefInvitationStatusResponse)
 
+    jest.mocked(prismaClient.userOrganisationInvitation.create).mockResolvedValueOnce(createUserOrgInvitation)
+
+    const mockUserOrganisation = Mock.of<UserOrganisationWithRelations>({
+      id: 123,
+      isDeleted: true,
+    })
+
+    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValueOnce(mockUserOrganisation)
+
+    const findSysRefRoleMock = jest
+      .mocked(prismaClient.sysRefRole.findFirstOrThrow)
+      .mockResolvedValueOnce(findSysRefRoleResponse)
+    const updateOrgMock = jest.mocked(prismaClient.organisation.update).mockResolvedValueOnce(updateOrgResponse)
+
+    const res = await testHandler(api, { method: 'POST', body })
+
+    expect(findSysRefRoleMock).toHaveBeenCalledWith({ where: { isDeleted: false, name: 'SponsorContact' } })
+
+    // Org is updated
+    expect(updateOrgMock).toHaveBeenCalledWith({
+      where: { id: Number(body.organisationId) },
+      include: {
+        users: {
+          select: {
+            id: true,
+            user: true,
+          },
+          where: {
+            user: {
+              email: body.emailAddress,
+            },
+          },
+        },
+      },
+      data: {
+        users: {
+          update: {
+            where: {
+              id: mockUserOrganisation.id,
+            },
+            data: {
+              isDeleted: false,
+              updatedBy: { connect: { id: userWithContactManagerRole.user?.id } },
+            },
+          },
+        },
+      },
+    })
+
+    // Send email
+    expect(emailService.sendEmail).toHaveBeenCalledWith({
+      subject: 'Assess the progress of your studies',
+      templateData: {
+        rdnLink: EXTERNAL_CRN_URL,
+        organisationName: updateOrgResponse.name,
+        requestSupportLink: `http://localhost:3000${SUPPORT_PAGE}`,
+        signInLink: 'http://localhost:3000/auth/signin',
+        termsAndConditionsLink: EXTERNAL_CRN_TERMS_CONDITIONS_URL,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      htmlTemplate: expect.any(Function),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- valid any
+      textTemplate: expect.any(Function),
+      to: body.emailAddress,
+    })
+
+    // Entry in UserOrganisationInvitation table is added
+    expect(prismaClient.userOrganisationInvitation.create).toHaveBeenCalledWith({
+      data: {
+        messageId,
+        timestamp: createUserOrgInvitation.timestamp,
+        status: {
+          connect: {
+            id: createUserOrgInvitation.statusId,
+          },
+        },
+        userOrganisation: {
+          connect: {
+            id: createUserOrgInvitation.userOrganisationId,
+          },
+        },
+        sentBy: {
+          connect: {
+            id: userWithContactManagerRole.user?.id,
+          },
+        },
+      },
+    })
+
+    // Redirect back to organisation page
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}?success=1`)
   })
 })
-
-/* -------------------------------------------------------------------------- */
-/* FAILURE CASES                                                              */
-/* -------------------------------------------------------------------------- */
 
 describe('Failed organisation sponsor contact invitation', () => {
   const body: OrganisationAddInputs = {
@@ -444,67 +555,79 @@ describe('Failed organisation sponsor contact invitation', () => {
 
   test('User not logged in redirects to sign in page', async () => {
     jest.mocked(getServerSession).mockResolvedValueOnce(null)
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
-      query: {},
-    })
+    const res = await testHandler(api, { method: 'POST', body, query: {} })
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(SIGN_IN_PAGE)
+    expect(logger.error).toHaveBeenCalledWith(new AuthError('Not signed in'))
   })
 
-  test('User without role is redirected', async () => {
+  test('User without having a required role is redirected to error page', async () => {
     jest.mocked(getServerSession).mockResolvedValueOnce(userNoRoles)
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
-      query: {},
-    })
+    const res = await testHandler(api, { method: 'POST', body, query: {} })
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/500`)
+    expect(logger.error).toHaveBeenCalledWith(new Error('User does not have a valid role'))
   })
 
-  test('Wrong http method returns fatal=1', async () => {
+  test('Wrong http method redirects back to the form with a fatal error', async () => {
     jest.mocked(getServerSession).mockResolvedValueOnce(userWithContactManagerRole)
-    const res = await testHandler(api, {
-      method: 'GET',
-      body,
-      query: {},
-    })
+    const res = await testHandler(api, { method: 'GET', body, query: {} })
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}/?fatal=1`)
+    expect(logger.error).toHaveBeenCalledWith(new Error('Wrong method'))
   })
 
-  test('Validation errors redirect to the form', async () => {
+  test('Validation errors redirects back to the form with the errors and original values', async () => {
     jest.mocked(getServerSession).mockResolvedValueOnce(userWithContactManagerRole)
+    jest.mocked(prismaClient.assessment.create).mockResolvedValueOnce(Mock.of<Assessment>({ id: 1 }))
+    jest.mocked(prismaClient.study.update).mockResolvedValueOnce(Mock.of<Study>({ id: 2 }))
 
-    const invalidBody = {
+    const bodyWithValidationIssue: Partial<OrganisationAddInputs> = {
       organisationId: '123',
+      emailAddress: undefined,
     }
 
-    const res = await testHandler(api, {
-      method: 'POST',
-      body: invalidBody,
-    })
+    const res = await testHandler(api, { method: 'POST', body: bodyWithValidationIssue })
 
+    expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe(`/organisations/123/?emailAddressError=Required`)
+    expect(logger.error).toHaveBeenCalledWith(
+      new ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['emailAddress'],
+          message: 'Required',
+        },
+      ])
+    )
   })
 
-  test('Attempting to invite existing contact returns fatal=2', async () => {
+  test('Attempting to invite already existing contact redirects with error', async () => {
     jest.mocked(getServerSession).mockResolvedValueOnce(userWithContactManagerRole)
+    jest.mocked(prismaClient.organisation.findFirst).mockResolvedValueOnce(findOrgResponse)
+    jest.mocked(prismaClient.sysRefRole.findFirstOrThrow).mockResolvedValueOnce(findSysRefRoleResponse)
 
-    jest.mocked(getOrganisationById).mockResolvedValue(findOrgResponse)
-
-    jest.mocked(prismaClient.sysRefRole.findFirstOrThrow).mockResolvedValue(findSysRefRoleResponse)
-
-    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValue({
+    const mockUserOrganisation = Mock.of<UserOrganisationWithRelations>({
       id: 123,
       isDeleted: false,
-    } as UserOrganisationWithRelations)
-
-    const res = await testHandler(api, {
-      method: 'POST',
-      body,
     })
 
-    expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}/?fatal=2`)
+    jest.mocked(prismaClient.userOrganisation.findFirst).mockResolvedValueOnce(mockUserOrganisation)
+
+    const res = await testHandler(api, { method: 'POST', body })
+
+    expect(jest.mocked(prismaClient.organisation.update)).not.toHaveBeenCalled()
+
     expect(emailService.sendEmail).not.toHaveBeenCalled()
+
+    expect(res.statusCode).toBe(302)
+    expect(res._getRedirectUrl()).toBe(`/organisations/${body.organisationId}/?fatal=2`)
+    expect(logger.error).toHaveBeenCalledWith(
+      'Tried to add contact with email %s to organisation %s, but active relationship already exists',
+      body.emailAddress,
+      findOrgResponse.name
+    )
   })
 })

--- a/apps/web/src/pages/api/forms/organisation.ts
+++ b/apps/web/src/pages/api/forms/organisation.ts
@@ -1,6 +1,5 @@
 import crypto from 'node:crypto'
 
-import { authService } from '@nihr-ui/auth'
 import { emailService } from '@nihr-ui/email'
 import { logger } from '@nihr-ui/logger'
 import { emailTemplates } from '@nihr-ui/templates/sponsor-engagement'
@@ -21,61 +20,6 @@ import { addUserToGroup, isUserEligibleForOdpRole } from './registration'
 
 export interface ExtendedNextApiRequest extends NextApiRequest {
   body: OrganisationAddInputs
-}
-
-// ---------- Helper: look up IDG and sync local user ----------
-async function lookupIdgAndSyncLocalUser(emailAddress: string) {
-  let identityGatewayId: string | null = null
-  let idgUserFound = false
-
-  const getUserResponse = await authService.getUser(emailAddress)
-
-  if (getUserResponse.success) {
-    const {
-      data: { totalResults, Resources },
-    } = getUserResponse
-
-    if (totalResults > 0 && Resources) {
-      const match = Resources.find((r) => Boolean(r.userName))
-      identityGatewayId = match?.userName ?? null
-      idgUserFound = identityGatewayId !== null
-
-      if (idgUserFound) {
-        logger.info('Found IDG account matching email %s', emailAddress)
-      }
-    } else {
-      logger.info('No IDG account found for %s — treating as new user', emailAddress)
-    }
-  }
-
-  let localUser = await prismaClient.user.findUnique({
-    where: { email: emailAddress },
-  })
-
-  if (!localUser) {
-    localUser = await prismaClient.user.create({
-      data: {
-        email: emailAddress,
-        ...(idgUserFound && {
-          identityGatewayId,
-          registrationConfirmed: true,
-          registrationToken: null,
-        }),
-      },
-    })
-  } else if (idgUserFound) {
-    localUser = await prismaClient.user.update({
-      where: { email: emailAddress },
-      data: {
-        identityGatewayId,
-        registrationConfirmed: true,
-        registrationToken: null,
-      },
-    })
-  }
-
-  const isNewToIDG = !idgUserFound
-  return { localUser, isNewToIDG, identityGatewayId }
 }
 
 export default withApiHandler<ExtendedNextApiRequest>(
@@ -111,7 +55,7 @@ export default withApiHandler<ExtendedNextApiRequest>(
         user: { id: requestedByUserId },
       } = session
 
-      const { isNewToIDG } = await lookupIdgAndSyncLocalUser(emailAddress)
+      const registrationToken = crypto.randomBytes(24).toString('hex')
 
       // Get existing user organisation record
       const userOrganisation = await prismaClient.userOrganisation.findFirst({
@@ -134,6 +78,14 @@ export default withApiHandler<ExtendedNextApiRequest>(
       if (userOrganisation) {
         logger.info('Re-adding contact with email %s to organisation %s', emailAddress, organisation.name)
       }
+
+      const existingUser = await prismaClient.user.findUnique({
+        where: {
+          email: emailAddress,
+        },
+      })
+
+      const shouldUpdateRegistrationToken = (existingUser?.identityGatewayId ?? null) === null
 
       // Add user to organisation
       const { name: organisationName, users } = await prismaClient.organisation.update({
@@ -171,7 +123,15 @@ export default withApiHandler<ExtendedNextApiRequest>(
                 createdBy: { connect: { id: requestedByUserId } },
                 updatedBy: { connect: { id: requestedByUserId } },
                 user: {
-                  connect: { email: emailAddress },
+                  connectOrCreate: {
+                    // If a user does not exist, create the user. We'll set registration token later.
+                    create: {
+                      email: emailAddress,
+                    },
+                    where: {
+                      email: emailAddress,
+                    },
+                  },
                 },
               },
             }),
@@ -181,24 +141,15 @@ export default withApiHandler<ExtendedNextApiRequest>(
 
       const userOrganisationId = users[0].id
 
-      let registrationToken: string | null = null
-      if (isNewToIDG) {
-        registrationToken = crypto.randomBytes(24).toString('hex')
-
-        await prismaClient.user.update({
-          where: {
-            email: emailAddress,
-          },
-          data: {
+      const user = await prismaClient.user.update({
+        where: {
+          email: emailAddress,
+        },
+        data: {
+          ...(shouldUpdateRegistrationToken && {
             registrationToken,
             registrationConfirmed: false,
-          },
-        })
-      }
-
-      const user = await prismaClient.user.update({
-        where: { email: emailAddress },
-        data: {
+          }),
           roles: {
             // If a user is not assigned the sponsor contact role, assign it
             createMany: {
@@ -213,13 +164,14 @@ export default withApiHandler<ExtendedNextApiRequest>(
         },
       })
 
+      const isNewUser = Boolean(user.registrationToken) && !user.registrationConfirmed
+
+      const savedRegistrationToken = user.registrationToken
+
       const isEligibleForOdpRole = await isUserEligibleForOdpRole(user.id)
       if (isEligibleForOdpRole) {
         await addUserToGroup(user.email, ODP_ROLE_GROUP_ID)
       }
-
-      const isNewUser = Boolean(registrationToken)
-      const signInLink = getAbsoluteUrl(`${SIGN_IN_PAGE}${isNewUser ? `?registrationToken=${registrationToken}` : ''}`)
 
       const { messageId } = await emailService.sendEmail({
         to: emailAddress,
@@ -229,7 +181,9 @@ export default withApiHandler<ExtendedNextApiRequest>(
         templateData: {
           organisationName,
           rdnLink: EXTERNAL_CRN_URL,
-          signInLink,
+          signInLink: getAbsoluteUrl(
+            `${SIGN_IN_PAGE}${isNewUser ? `?registrationToken=${savedRegistrationToken}` : ``}`
+          ),
           requestSupportLink: getAbsoluteUrl(SUPPORT_PAGE),
           termsAndConditionsLink: EXTERNAL_CRN_TERMS_CONDITIONS_URL,
         },


### PR DESCRIPTION
Reverts PA-NIHR-CRN/sponsor-engagement-web#459
reverting 2964, due to new issue, current fix would need to be applied to other locations, more suitable location for a future proof fix would be within the registration flow https://github.com/PA-NIHR-CRN/sponsor-engagement-web/blob/main/apps/web/src/pages/api/forms/registration.ts