### PR TITLE
SE-315 - Study list UI updates - implement new Needs Action chips and logic

### DIFF
--- a/apps/web/src/__tests__/Studies.spec.tsx
+++ b/apps/web/src/__tests__/Studies.spec.tsx
@@ -130,7 +130,7 @@ describe('Studies page', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Assess progress of studies' })).toBeInTheDocument()
 
     // Total studies needing assessment
-    expect(screen.getByText(`There are 3 studies to assess`)).toBeInTheDocument()
+    expect(screen.getByText(`There are 3 studies needing action`)).toBeInTheDocument()
 
     // Description
     expect(
@@ -172,7 +172,7 @@ describe('Studies page', () => {
     ).toHaveAttribute('href', '/api/export')
 
     // Study results title
-    expect(screen.getByText(`${mockStudies.length} studies found (3 due for assessment)`)).toBeInTheDocument()
+    expect(screen.getByText(`${mockStudies.length} studies found (3 need action)`)).toBeInTheDocument()
 
     // Sort
     expect(screen.getByRole('combobox', { name: 'Sort by' })).toBeInTheDocument()
@@ -195,11 +195,8 @@ describe('Studies page', () => {
     ).toBeInTheDocument()
 
     // Study due assessment
-    expect(withinFirstStudy.getByText('Due for 4 days')).toBeInTheDocument()
-    expect(withinSecondStudy.queryByText(/Due/)).not.toBeInTheDocument()
-
-    // Study indicators
-    expect(withinFirstStudy.getByText('Milestone missed, Recruitment concerns')).toBeInTheDocument()
+    expect(withinFirstStudy.getByText('Assessment due for 4 days')).toBeInTheDocument()
+    expect(withinSecondStudy.queryByText(/Assessment/)).not.toBeInTheDocument()
 
     // Study assessment status
     expect(withinFirstStudy.getByText('Off Track on 1 January 2001')).toBeInTheDocument()
@@ -242,7 +239,7 @@ describe('Studies page', () => {
     )
 
     // Study results title
-    expect(screen.getByText(`0 studies found (0 due for assessment)`)).toBeInTheDocument()
+    expect(screen.getByText(`0 studies found (0 need action)`)).toBeInTheDocument()
 
     // Show message instead of the table
     expect(screen.getByText('No studies found')).toBeInTheDocument()

--- a/apps/web/src/components/atoms/Tag/Tag.tsx
+++ b/apps/web/src/components/atoms/Tag/Tag.tsx
@@ -20,7 +20,7 @@ function Tag({
     text,
     children,
     className,
-}: TagProps) {
+}: Readonly<TagProps>) {
     if (!text && !children) return null;
 
     return (

--- a/apps/web/src/components/atoms/Tag/Tag.tsx
+++ b/apps/web/src/components/atoms/Tag/Tag.tsx
@@ -1,0 +1,42 @@
+export type TagColour = 'red' | 'blue' | 'green' | 'yellow' | 'grey';
+
+const colourClassMap: Record<TagColour, string> = {
+    red: 'govuk-tag--red',
+    blue: 'govuk-tag--blue',
+    green: 'govuk-tag--green',
+    yellow: 'govuk-tag--yellow',
+    grey: 'govuk-tag--grey',
+};
+
+export interface TagProps {
+    colour?: TagColour;
+    text?: string;
+    children?: React.ReactNode;
+    className?: string;
+}
+
+function Tag({
+    colour = 'red',
+    text,
+    children,
+    className,
+}: TagProps) {
+    if (!text && !children) return null;
+
+    return (
+        <span
+            className={[
+                'govuk-tag',
+                colourClassMap[colour],
+                'normal-case',
+                className,
+            ]
+                .filter(Boolean)
+                .join(' ')}
+        >
+            {children ?? text}
+        </span>
+    );
+}
+
+export default Tag;

--- a/apps/web/src/components/molecules/TagCollection/TagCollection.tsx
+++ b/apps/web/src/components/molecules/TagCollection/TagCollection.tsx
@@ -1,0 +1,18 @@
+import type { TagProps } from '@/components/atoms/Tag/Tag';
+import Tag from '@/components/atoms/Tag/Tag';
+
+export interface TagCollectionProps {
+    tags: TagProps[];
+}
+
+function TagCollection({ tags }: TagCollectionProps) {
+    return (
+        <div className="flex gap-2">
+            {tags.map((tag) => (
+                <Tag key={tag.text} {...tag} />
+            ))}
+        </div>
+    );
+}
+
+export default TagCollection;

--- a/apps/web/src/components/molecules/TagCollection/TagCollection.tsx
+++ b/apps/web/src/components/molecules/TagCollection/TagCollection.tsx
@@ -5,7 +5,9 @@ export interface TagCollectionProps {
     tags: TagProps[];
 }
 
-function TagCollection({ tags }: TagCollectionProps) {
+function TagCollection({
+    tags,
+}: Readonly<TagCollectionProps>) {
     return (
         <div className="flex gap-2">
             {tags.map((tag) => (

--- a/apps/web/src/components/molecules/cards/StudyList/StudyList.spec.tsx
+++ b/apps/web/src/components/molecules/cards/StudyList/StudyList.spec.tsx
@@ -13,7 +13,7 @@ describe('StudyList Component', () => {
     lastAssessmentDate: '2023-09-30',
     trackStatus: 'On track',
     trackStatusHref: '/track/on',
-    indications: ['Indication ABC'],
+    indications: undefined,
     daysSinceAssessmentDue: null,
     irasId: '31832',
   }
@@ -28,8 +28,6 @@ describe('StudyList Component', () => {
     const lastAssessmentTrackStatusElement = screen.getByText('On track')
     const lastAssessmentDateHeading = screen.getByText('Last sponsor assessment')
     const lastAssessmentDateElement = screen.getByText('on 2023-09-30')
-    const indicationHeading = screen.getByText('Study data indicates')
-    const indicationElement = screen.getByText('Indication ABC')
     const viewStudyButtonElement = screen.getByText('View study')
 
     expect(sponsorNameElement).toBeInTheDocument()
@@ -38,8 +36,6 @@ describe('StudyList Component', () => {
     expect(lastAssessmentTrackStatusElement).toHaveAttribute('href', defaultProps.trackStatusHref)
     expect(lastAssessmentDateHeading).toBeInTheDocument()
     expect(lastAssessmentDateElement).toBeInTheDocument()
-    expect(indicationHeading).toBeInTheDocument()
-    expect(indicationElement).toBeInTheDocument()
     expect(viewStudyButtonElement).toHaveAttribute('href', defaultProps.studyHref)
   })
 
@@ -47,7 +43,7 @@ describe('StudyList Component', () => {
     render(<StudyList {...defaultProps} daysSinceAssessmentDue={0} />)
 
     // Check if the "Due" tag is rendered
-    const dueTagElement = screen.getByText('Due for 1 day')
+    const dueTagElement = screen.getByText('Assessment due for 1 day')
     expect(dueTagElement).toBeInTheDocument()
   })
 
@@ -55,7 +51,7 @@ describe('StudyList Component', () => {
     render(<StudyList {...defaultProps} daysSinceAssessmentDue={1} />)
 
     // Check if the "Due" tag is rendered
-    const dueTagElement = screen.getByText('Due for 1 day')
+    const dueTagElement = screen.getByText('Assessment due for 1 day')
     expect(dueTagElement).toBeInTheDocument()
   })
 
@@ -63,7 +59,7 @@ describe('StudyList Component', () => {
     render(<StudyList {...defaultProps} daysSinceAssessmentDue={2} />)
 
     // Check if the "Due" tag is rendered
-    const dueTagElement = screen.getByText('Due for 2 days')
+    const dueTagElement = screen.getByText('Assessment due for 2 days')
     expect(dueTagElement).toBeInTheDocument()
   })
 
@@ -73,6 +69,62 @@ describe('StudyList Component', () => {
     // Check if the "Due" tag is not rendered
     const dueTagElement = screen.queryByText('Due')
     expect(dueTagElement).toBeNull()
+  })
+
+  test('renders correct "Data updates required" tag when indications conatins only included values', () => {
+    render(<StudyList {...defaultProps} indications={['Recruitment target met']} />)
+
+    // Check if the "Data updates required" tag is rendered
+    const dataUpdatesRequiredTagElement = screen.getByText('Data updates required')
+    expect(dataUpdatesRequiredTagElement).toBeInTheDocument()
+  })
+
+  test('renders correct "Data updates required" tag when indications conatins included and excluded values', () => {
+    render(<StudyList {...defaultProps} indications={['Recruitment target met', 'No recruitment for 6 months']} />)
+
+    // Check if the "Data updates required" tag is rendered
+    const dataUpdatesRequiredTagElement = screen.getByText('Data updates required')
+    expect(dataUpdatesRequiredTagElement).toBeInTheDocument()
+  })
+
+  test('does not render "Data updates required" tag when indications conatins only excluded values', () => {
+    render(<StudyList {...defaultProps} indications={['Recruiting at a lower rate than expected (RTT)', 'No recruitment in past 6 months']} />)
+
+    // Check if the "Data updates required" tag is not rendered
+    const dataUpdatesRequiredTagElement = screen.queryByText('Due')
+    expect(dataUpdatesRequiredTagElement).toBeNull()
+  })
+
+  test('renders correct "Needs action" tag when data updates required', () => {
+    render(<StudyList {...defaultProps} indications={['Recruitment target met', 'No recruitment for 6 months']} />)
+
+    // Check if the "Needs action" tag is rendered
+    const needsActionTagElement = screen.getByText('Needs action')
+    expect(needsActionTagElement).toBeInTheDocument()
+  })
+
+  test('renders correct "Needs action" tag when when daysSinceAssessmentDue is greater than 1', () => {
+    render(<StudyList {...defaultProps} daysSinceAssessmentDue={2} />)
+
+    // Check if the "Needs action" tag is rendered
+    const needsActionTagElement = screen.getByText('Needs action')
+    expect(needsActionTagElement).toBeInTheDocument()
+  })
+
+  test('renders correct "Needs action" tag when when daysSinceAssessmentDue is greater than 1 and Data updates required', () => {
+    render(<StudyList {...defaultProps} daysSinceAssessmentDue={2} indications={['No recruitment for 6 months']}  />)
+
+    // Check if the "Needs action" tag is rendered
+    const needsActionTagElement = screen.getByText('Needs action')
+    expect(needsActionTagElement).toBeInTheDocument()
+  })
+
+  test('does not render "Needs action" tag when when daysSinceAssessmentDue is undefined and Data updates are not required', () => {
+    render(<StudyList {...defaultProps} daysSinceAssessmentDue={null} indications={['No recruitment in past 6 months']}  />)
+
+    // Check if the "Needs action" tag is rendered
+    const needsActionTagElement = screen.queryByText('Needs action')
+    expect(needsActionTagElement).toBeNull()
   })
 
   test('renders with different sponsorName, irasId and shortTitle', () => {

--- a/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
+++ b/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
@@ -32,10 +32,12 @@ export function StudyList({
 }: StudyListProps) {
   const hasAssessmentDue = daysSinceAssessmentDue !== null
 
-  const daysDueText =
-    hasAssessmentDue
-      ? `Assessment due for ${daysSinceAssessmentDue || '1'} day${daysSinceAssessmentDue > 1 ? 's' : ''}`
-      : ''
+  const daysDueText = hasAssessmentDue
+    ? (() => {
+      const days = daysSinceAssessmentDue || 1;
+      return `Assessment due for ${days} day${days > 1 ? 's' : ''}`;
+    })()
+    : '';
 
   const excludedIndications = new Set([
     'Recruiting at a lower rate than expected (RTT)',
@@ -48,7 +50,7 @@ export function StudyList({
   return (
     <Card>
 
-      {(hasAssessmentDue || areUpdatesRequired) ? <Tag className='absolute top-0 right-0' text="Needs action"/> : null}
+      {(hasAssessmentDue || areUpdatesRequired) ? <Tag className='absolute top-0 right-0' text="Needs action" /> : null}
 
       <div className="md:max-w-[calc(100%-50px)]">
         <div className="text-darkGrey govuk-!-margin-bottom-1 max-w-[calc(100%-45px)] lg:max-w-auto govuk-body-s">

--- a/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
+++ b/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 
 import { Card } from '@/components/atoms'
+import Tag from '@/components/atoms/Tag/Tag'
+
+import TagCollection from '../../TagCollection/TagCollection'
 
 export interface StudyListProps {
   sponsorOrgName?: string
@@ -27,19 +30,25 @@ export function StudyList({
   indications,
   irasId,
 }: StudyListProps) {
+  const hasAssessmentDue = daysSinceAssessmentDue !== null
+
   const daysDueText =
-    daysSinceAssessmentDue !== null
-      ? `Due for ${daysSinceAssessmentDue || '1'} day${daysSinceAssessmentDue > 1 ? 's' : ''}`
+    hasAssessmentDue
+      ? `Assessment due for ${daysSinceAssessmentDue || '1'} day${daysSinceAssessmentDue > 1 ? 's' : ''}`
       : ''
+
+  const excludedIndications = new Set([
+    'Recruiting at a lower rate than expected (RTT)',
+    'No recruitment in past 6 months',
+  ])
+
+  const areUpdatesRequired =
+    indications?.some(indication => !excludedIndications.has(indication)) ?? false
 
   return (
     <Card>
-      {daysSinceAssessmentDue !== null ? (
-        <>
-          <span className="govuk-visually-hidden">{shortTitle} has been</span>
-          <span className="govuk-tag govuk-tag--red float-right -mt-3 -mr-3 normal-case">{daysDueText}</span>
-        </>
-      ) : null}
+
+      {(hasAssessmentDue || areUpdatesRequired) ? <Tag className='absolute top-0 right-0' text="Needs action"/> : null}
 
       <div className="md:max-w-[calc(100%-50px)]">
         <div className="text-darkGrey govuk-!-margin-bottom-1 max-w-[calc(100%-45px)] lg:max-w-auto govuk-body-s">
@@ -57,7 +66,7 @@ export function StudyList({
       <div className="sm:flex sm:justify-between lg:justify-normal sm:gap-3">
         <div className="lg:min-w-[320px]">
           <strong className="govuk-heading-s govuk-!-margin-bottom-0">Last sponsor assessment</strong>
-          <p className="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0">
+          <p className="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-2">
             {trackStatus ? (
               <>
                 {trackStatusHref ? (
@@ -74,14 +83,20 @@ export function StudyList({
             )}
           </p>
         </div>
+      </div>
 
-        <div className="lg:min-w-[320px]">
-          <strong className="govuk-heading-s govuk-!-margin-bottom-0">Study data indicates</strong>
-          <p className="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-            {indications?.length ? indications.join(', ') : 'No concerns'}
-          </p>
-        </div>
+      <TagCollection
+        tags={[
+          ...(hasAssessmentDue
+            ? [{ text: daysDueText }]
+            : []),
+          ...(areUpdatesRequired
+            ? [{ text: 'Data updates required' }]
+            : []),
+        ]}
+      />
 
+      <div className="sm:justify-between lg:justify-normal sm:gap-3">
         <div className="text-right lg:w-full">
           <Link
             aria-label={`View study ${shortTitle}`}

--- a/apps/web/src/pages/studies/index.tsx
+++ b/apps/web/src/pages/studies/index.tsx
@@ -12,6 +12,7 @@ import type { ReactElement } from 'react'
 import type { OrderType } from '@/@types/filters'
 import type { TypeBannerSkeleton } from '@/@types/generated'
 import { Card } from '@/components/atoms'
+import Tag from '@/components/atoms/Tag/Tag'
 import {
   Filters,
   Pagination,
@@ -63,8 +64,8 @@ export default function Studies({
     totalItems === 0
       ? `(no matching search results)`
       : `(${totalItems} ${pluraliseStudy(totalItems)}, page ${initialPage} of ${Math.ceil(
-          totalItems / initialPageSize
-        )})`
+        totalItems / initialPageSize
+      )})`
 
   const today = dayjs()
 
@@ -80,11 +81,13 @@ export default function Studies({
 
           <h2 className="govuk-heading-l govuk-!-margin-bottom-4">Assess progress of studies</h2>
 
-          <div className="flex items-center gap-2 govuk-!-margin-bottom-4">
-            <AlertIcon />{' '}
-            <strong className="govuk-heading-s govuk-!-margin-bottom-0">
-              There are {totalItemsDue} studies to assess
-            </strong>
+          <div className="govuk-!-margin-bottom-4">
+            <Tag className="flex items-center gap-2 govuk-!-padding-3 block w-full">
+                <AlertIcon />
+                <strong className="govuk-heading-s govuk-!-margin-bottom-0">
+                  There are {totalItemsDue} studies needing action
+                </strong>
+            </Tag>
           </div>
 
           <p className="govuk-body">
@@ -118,7 +121,7 @@ export default function Studies({
           <div className="flex-wrap items-center justify-between gap-3 md:flex govuk-!-margin-bottom-4">
             <p className="govuk-heading-s mb-0 whitespace-nowrap">{`${totalItems} ${pluraliseStudy(
               totalItems
-            )} found (${totalItemsDue} due for assessment)`}</p>
+            )} found (${totalItemsDue} need action)`}</p>
             <div className="govuk-form-group mt-2 items-center justify-end md:my-0 md:flex">
               <div className="items-center whitespace-nowrap md:flex">
                 <Sort defaultOrder={filters.order} form="filters-form" />
@@ -143,7 +146,7 @@ export default function Studies({
                           <StudyList
                             daysSinceAssessmentDue={daysSinceAssessmentDue}
                             indications={study.evaluationCategories
-                              .map((evalCategory) => evalCategory.indicatorType)
+                              .map((evalCategory) => evalCategory.indicatorValue)
                               .filter((evalCategory, index, items) => items.indexOf(evalCategory) === index)}
                             irasId={study.irasId}
                             lastAssessmentDate={study.lastAssessment ? formatDate(study.lastAssessment.createdAt) : ''}


### PR DESCRIPTION
- Adding `Tag` and `TagCollection` components
- Updating `StudyList` to include new tags for Assessment due and data updates required
- Updating the global summary banner to use a new `Tag` component
- Removing legacy labels and updating naming to move away from Assessment needed to needing action 
- Updating & adding tests