### PR TITLE
SE-316: Study details UI updates - High level numbers (mini dashboard)

### DIFF
--- a/apps/web/src/components/atoms/SummaryCard/SummaryCard.tsx
+++ b/apps/web/src/components/atoms/SummaryCard/SummaryCard.tsx
@@ -1,0 +1,19 @@
+export interface SummaryCardProps {
+  title: string
+  content: React.ReactNode
+}
+
+function SummaryCard({ title, content }: Readonly<SummaryCardProps>) {
+  return (
+    <div className="govuk-summary-card govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+      <div className="govuk-summary-card__title-wrapper">
+        <h2 className="govuk-summary-card__title text-darkGrey">{title}</h2>
+      </div>
+      <div className="govuk-summary-card__content">
+        <p className="govuk-heading-l govuk-!-margin-0">{content}</p>
+      </div>
+    </div>
+  )
+}
+
+export default SummaryCard

--- a/apps/web/src/components/molecules/SummaryCardCollection/SummaryCardCollection.tsx
+++ b/apps/web/src/components/molecules/SummaryCardCollection/SummaryCardCollection.tsx
@@ -1,0 +1,20 @@
+import type { SummaryCardProps } from '@/components/atoms/SummaryCard/SummaryCard'
+import SummaryCard from '@/components/atoms/SummaryCard/SummaryCard'
+
+export interface SummaryCardCollectionProps {
+  panels: SummaryCardProps[]
+}
+
+function SummaryCardCollection({ panels }: Readonly<SummaryCardCollectionProps>) {
+  return (
+    <div className="govuk-summary-cards">
+      {panels.map((panel) => (
+        <div key={panel.title}>
+          <SummaryCard {...panel} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default SummaryCardCollection

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -8,6 +8,7 @@ import type { ReactElement } from 'react'
 import type { LeadAdministrationId } from 'shared-utilities/src/utils/lead-administration-id'
 
 import { Status } from '@/@types/studies'
+import type { SummaryCardProps } from '@/components/atoms/SummaryCard/SummaryCard'
 import {
   AssessmentHistory,
   EditHistory,
@@ -16,8 +17,10 @@ import {
   StudyDetails,
 } from '@/components/molecules'
 import { getEditHistory } from '@/components/molecules/EditHistory/utils'
+import SummaryCardCollection from '@/components/molecules/SummaryCardCollection/SummaryCardCollection'
 import { RootLayout } from '@/components/organisms'
 import { Roles } from '@/constants'
+import { FormStudyStatus } from '@/constants/editStudyForm'
 import { FORM_SUCCESS_MESSAGES } from '@/constants/forms'
 import { getAssessmentPageRoute, STUDIES_PAGE, SUPPORT_PAGE } from '@/constants/routes'
 import { getStudyByIdFromCPMS } from '@/lib/cpms/studies'
@@ -73,6 +76,60 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
     [Status.Suspended, Status.SuspendedFromOpenToRecruitment, Status.SuspendedFromOpenWithRecruitment] as string[]
   ).includes(study.studyStatus)
 
+  const formStatus = mapCPMSStatusToFormStatus(study.studyStatus) as FormStudyStatus
+
+  const panelsByStatus: Partial<Record<FormStudyStatus, SummaryCardProps[]>> = {
+    [FormStudyStatus.Suspended]: [
+      {
+        title: 'Study status',
+        content: formStatus,
+      },
+      {
+        title: 'Recruitment total',
+        content: study.totalRecruitmentToDate?.toString() ?? '-',
+      },
+      {
+        title: 'Estimated reopening date',
+        content: study.estimatedReopeningDate?.toLocaleDateString('en-GB') ?? '-',
+      },
+    ],
+
+    [FormStudyStatus.InSetup]: [
+      {
+        title: 'Study status',
+        content: formStatus,
+      },
+      {
+        title: 'Planned UK target',
+        content: study.sampleSize?.toString() ?? '-',
+      },
+      {
+        title: 'Planned open to recruitment date',
+        content: study.plannedOpeningDate?.toLocaleDateString('en-GB') ?? '-',
+      },
+    ],
+
+    [FormStudyStatus.OpenToRecruitment]: [
+      {
+        title: 'Study status',
+        content: formStatus,
+      },
+      {
+        title: 'Recruitment numbers',
+        content:
+          study.totalRecruitmentToDate !== null && study.sampleSize !== null
+            ? `${study.totalRecruitmentToDate} of ${study.sampleSize}`
+            : '-',
+      },
+      {
+        title: 'Planned closure date',
+        content: study.plannedClosureDate?.toLocaleDateString('en-GB') ?? '-',
+      },
+    ],
+  }
+
+  const panels = panelsByStatus[formStatus] ?? []
+
   return (
     <Container>
       <NextSeo title={`Study Progress Review - ${study.shortTitle}`} />
@@ -90,6 +147,8 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
             {organisationsByRole.Sponsor}
             {Boolean(supportOrgName) && ` (${supportOrgName})`}
           </span>
+
+          <SummaryCardCollection panels={panels} />
 
           <div className="flex flex-col govuk-!-margin-bottom-4 govuk-!-margin-top-4 gap-6">
             {Boolean(study.dueAssessmentAt) && (
@@ -134,7 +193,7 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
             <Table.Body>
               <Table.Row>
                 <Table.CellHeader className="w-1/3">Study Status</Table.CellHeader>
-                <Table.Cell>{mapCPMSStatusToFormStatus(study.studyStatus)}</Table.Cell>
+                <Table.Cell>{formStatus}</Table.Cell>
               </Table.Row>
               <Table.Row>
                 <Table.CellHeader className="w-1/3">Study data indicates</Table.CellHeader>

--- a/packages/ui/globals.scss
+++ b/packages/ui/globals.scss
@@ -29,6 +29,8 @@ $govuk-link-colour: var(--colour-blue);
 
 @import '../../node_modules/govuk-frontend/govuk/all.scss';
 
+@import './summary-card.scss';
+
 @layer utilities {
   .focusable {
     &:focus {

--- a/packages/ui/summary-card.scss
+++ b/packages/ui/summary-card.scss
@@ -1,0 +1,20 @@
+.govuk-summary-cards {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.govuk-summary-cards > * {
+  flex: 1;
+  display: flex;
+}
+
+.govuk-summary-card {
+  border: none;
+  border-top: 5px solid var(--colour-blue);
+  background-color: var(--colour-grey-50);
+  flex: 1;
+}
+
+.govuk-summary-card__title-wrapper {
+  min-height: 6rem;
+}


### PR DESCRIPTION
- Adding SummaryCard and SummaryCardCollection components
- Updating study summary page to include collection of SummaryCard components
- Logic to display different cards based on study status as defined in [ticket](https://nihr.atlassian.net/jira/software/projects/SE/boards/135?selectedIssue=SE-316)