### PR TITLE
SE-327: Updating opt out screen to include progress bar

### DIFF
--- a/apps/web/src/components/atoms/ProgressBar/ProgressBar.tsx
+++ b/apps/web/src/components/atoms/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import type { ReactNode } from 'react'
 
 export interface ProgressBarProps {
   max: number
@@ -21,17 +20,16 @@ function GetProgressBarColorClass(color: progressBarColor) {
     return "progress-bar-warning";
   } else if (color === progressBarColor.Error) {
     return "progress-bar-error";
-  } else {
-    return ""
   }
+  return ""
 }
 
 export function ProgressBar({ max, color = progressBarColor.Default, value, className }: ProgressBarProps) {
   const colorClass = GetProgressBarColorClass(color);
-  
+
   const limitedValue = Math.min(max, Math.max(0, value));
-  
+
   return (
-      <progress max={max} value={limitedValue} className={clsx("progress-bar", colorClass, className)}></progress>
+    <progress className={clsx("progress-bar", colorClass, className)} max={max} value={limitedValue} />
   )
 }

--- a/apps/web/src/components/molecules/StudyDetails/StudyProgress.tsx
+++ b/apps/web/src/components/molecules/StudyDetails/StudyProgress.tsx
@@ -1,7 +1,7 @@
-import type {getStudyById} from '@/lib/studies'
-import {ProgressBar, progressBarColor} from "@/components/atoms/ProgressBar/ProgressBar";
-import {StudyDetailsProps} from "@/components/molecules";
 import clsx from "clsx";
+
+import { ProgressBar, progressBarColor } from "@/components/atoms/ProgressBar/ProgressBar";
+import { pluraliseDays } from "@/utils/pluralise";
 
 const maxDaysSinceAssessmentDue = 90
 
@@ -12,40 +12,28 @@ export interface StudyProgressProps {
 function GetStudyProgressColor(daysSinceAssessmentDue: number) {
     if (daysSinceAssessmentDue >= maxDaysSinceAssessmentDue) {
         return progressBarColor.Error;
-    } else {
-        return progressBarColor.Warning;
     }
-}
+    return progressBarColor.Warning;
 
-function AsDaysString(days: number)
-{
-    if (days == 1) {
-        return "1 day";
-    }
-    else {
-        return days + " days";
-    }
-        
 }
 
 function GetOverdueText(remainingDays: number) {
-    
+
     if (remainingDays < 0) {
-        return "OVERDUE by " + AsDaysString(Math.abs(remainingDays)); 
-    }    
-    else {
-        return AsDaysString(remainingDays) + " remaining";
+        return `OVERDUE by ${Math.abs(remainingDays)} ${pluraliseDays(Math.abs(remainingDays))}`;
     }
+
+    return `${remainingDays} ${pluraliseDays(remainingDays)} remaining`;
 }
 
-export function StudyProgress({elapsedDays}: StudyProgressProps) {
+export function StudyProgress({ elapsedDays }: StudyProgressProps) {
     const remainingDays = maxDaysSinceAssessmentDue - elapsedDays;
     const overdueTextClass = remainingDays < 0 ? "text-red" : "";
     return (
         <div>
             <div>
-                <ProgressBar className="govuk-!-width-full" max={90} value={elapsedDays}
-                             color={GetStudyProgressColor(elapsedDays)}/>
+                <ProgressBar className="govuk-!-width-full" color={GetStudyProgressColor(elapsedDays)} max={maxDaysSinceAssessmentDue}
+                    value={elapsedDays} />
             </div>
 
             <div className="govuk-grid-row">

--- a/apps/web/src/components/molecules/StudyProgressExtended/StudyProgressExtended.tsx
+++ b/apps/web/src/components/molecules/StudyProgressExtended/StudyProgressExtended.tsx
@@ -1,15 +1,35 @@
 import Link from 'next/link';
 import React from "react";
 
+import { Status } from '@/@types/studies';
 import { ProgressBar, progressBarColor } from "@/components/atoms/ProgressBar/ProgressBar";
 import { pluraliseDays } from '@/utils/pluralise';
 
 interface StudyProgressExtendedProps {
-    hraApprovalDate: Date;
+    hraApprovalDate: Date | null;
+    studyStatus: string;
+    willRecruitWithinTimeline: boolean;
     moreDetailsHref?: string;
 }
 
-export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({ hraApprovalDate, moreDetailsHref }) => {
+export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({ hraApprovalDate, studyStatus, willRecruitWithinTimeline, moreDetailsHref }) => {
+    
+    const inSetupStatuses = [
+        Status.InSetup,
+        Status.InSetupPendingNHSPermission,
+        Status.InSetupApprovalReceived,
+        Status.InSetupPendingApproval,
+        Status.InSetupNHSPermissionReceived
+    ];
+
+    if (
+        !inSetupStatuses.includes(studyStatus as Status) ||
+        hraApprovalDate === null ||
+        !willRecruitWithinTimeline
+    ) {
+        return null;
+    }
+    
     const today = new Date();
     const totalDays = 90;
     const endDate = new Date(hraApprovalDate);

--- a/apps/web/src/components/molecules/StudyProgressExtended/StudyProgressExtended.tsx
+++ b/apps/web/src/components/molecules/StudyProgressExtended/StudyProgressExtended.tsx
@@ -1,78 +1,56 @@
-import React from "react";
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { Status } from '@/@types/studies'
-import {ProgressBar, progressBarColor} from "@/components/atoms/ProgressBar/ProgressBar";
+import React from "react";
 
-type StudyProgressExtendedProps = {
-    hraApprovalDate: Date | null;
-    studyStatus: string;
-    willRecruitWithinTimeline: boolean;
-};
+import { ProgressBar, progressBarColor } from "@/components/atoms/ProgressBar/ProgressBar";
+import { pluraliseDays } from '@/utils/pluralise';
 
-export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({hraApprovalDate, studyStatus, willRecruitWithinTimeline }) => {
+interface StudyProgressExtendedProps {
+    hraApprovalDate: Date;
+    moreDetailsHref?: string;
+}
 
-    const inSetupStatuses = [
-        Status.InSetup,
-        Status.InSetupPendingNHSPermission,
-        Status.InSetupApprovalReceived,
-        Status.InSetupPendingApproval,
-        Status.InSetupNHSPermissionReceived
-    ];
-
-    if (
-        !inSetupStatuses.includes(studyStatus as Status) ||
-        hraApprovalDate == null ||
-        !willRecruitWithinTimeline
-    ) {
-        return null;
-    }
-    
+export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({ hraApprovalDate, moreDetailsHref }) => {
     const today = new Date();
     const totalDays = 90;
     const endDate = new Date(hraApprovalDate);
     endDate.setDate(endDate.getDate() + totalDays);
-    
+
     const elapsedDays = Math.ceil(
         (today.getTime() - hraApprovalDate.getTime()) / (1000 * 60 * 60 * 24)
     );
 
     const daysRemaining = Math.max(totalDays - elapsedDays, 0);
 
-    const pathname = usePathname();
-
     const progressLabel =
         elapsedDays >= totalDays
-            ? `OVER TARGET by ${elapsedDays - totalDays} days`
-            : `${daysRemaining} days remaining`;
+            ? `OVER TARGET by ${elapsedDays - totalDays} ${pluraliseDays(elapsedDays - totalDays)}`
+            : `${daysRemaining} ${pluraliseDays(daysRemaining)} remaining`;
 
     function GetStudyProgressColor(daysSinceAssessmentDue: number) {
         if (daysSinceAssessmentDue >= totalDays) {
             return progressBarColor.Error;
-        } else {
-            return progressBarColor.Warning;
         }
+        return progressBarColor.Warning;
     }
 
     return (
-        <div className="govuk-!-padding-3 relative bg-white border-grey-120 border border-b-2">
-            <h3 className="govuk-heading-m govuk-!-margin-bottom-1 p-0">
+        <div className="border-grey-50 border-b-2 border-t-2 govuk-!-margin-bottom-4">
+            <h3 className="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-4 p-0">
                 Progress of study setup
             </h3>
 
-            <span className="govuk-body-s text-darkGrey block mb-2">
+            <span className="govuk-body-s text-darkGrey block govuk-!-margin-bottom-2">
                 Based on the latest data from HRA approval from start date to end date
             </span>
 
-            <ProgressBar className="govuk-!-width-full" max={90} value={elapsedDays}
-                         color={GetStudyProgressColor(elapsedDays)}/>
-            
+            <ProgressBar className="govuk-!-width-full" color={GetStudyProgressColor(elapsedDays)} max={totalDays}
+                value={elapsedDays} />
+
             <div className="flex justify-between">
                 <div className="flex flex-col">
                     <span
-                        className={`govuk-body-s govuk-!-font-weight-bold ${
-                            daysRemaining === 0 ? "govuk-error-message text-red-600" : "text-darkGrey"
-                        }`}>
+                        className={`govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-2 ${daysRemaining === 0 ? "govuk-error-message text-red-600" : ""
+                            }`}>
                         {progressLabel}
                     </span>
 
@@ -80,9 +58,9 @@ export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({hra
                         HRA approval date: {hraApprovalDate.toLocaleDateString('en-GB')}
                     </span>
                 </div>
-                
+
                 <div className="flex flex-col text-right">
-                    <span className="govuk-body-s govuk-!-font-weight-bold text-darkGrey">
+                    <span className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-2 text-darkGrey">
                         {elapsedDays} / {totalDays} Days
                     </span>
                     <span className="govuk-body-s govuk-!-font-weight-bold text-darkGrey">
@@ -91,9 +69,11 @@ export const StudyProgressExtended: React.FC<StudyProgressExtendedProps> = ({hra
                 </div>
             </div>
 
-            <Link href={`${pathname}/configure`}>
-                More details
-            </Link>
+            {moreDetailsHref ? <span className="govuk-body-m block govuk-!-margin-bottom-4">
+                <Link href={moreDetailsHref}>
+                    More details
+                </Link>
+            </span> : null}
 
         </div>
     );

--- a/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
+++ b/apps/web/src/components/molecules/cards/StudyList/StudyList.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 
 import { Card } from '@/components/atoms'
-import Tag from '@/components/atoms/Tag/Tag'
-import TagCollection from '../../TagCollection/TagCollection'
 import {ProgressBar, progressBarColor} from "@/components/atoms/ProgressBar/ProgressBar";
+import Tag from '@/components/atoms/Tag/Tag'
 import {StudyProgress} from "@/components/molecules/StudyDetails/StudyProgress";
+
+import TagCollection from '../../TagCollection/TagCollection'
 
 export interface StudyListProps {
   sponsorOrgName?: string

--- a/apps/web/src/pages/studies/[studyId]/configure.tsx
+++ b/apps/web/src/pages/studies/[studyId]/configure.tsx
@@ -10,7 +10,7 @@ import { useForm } from 'react-hook-form'
 
 import { Fieldset, Form, Radio, RadioGroup } from '@/components/atoms'
 import { Textarea } from '@/components/atoms/Form/Textarea/Textarea'
-import { RequestSupport } from '@/components/molecules'
+import { RequestSupport, StudyProgressExtended } from '@/components/molecules'
 import { RootLayout } from '@/components/organisms'
 import { Roles } from '@/constants'
 import { TEXTAREA_MAX_CHARACTERS } from '@/constants/forms'
@@ -97,12 +97,17 @@ export default function Configure({ study, returnUrl }: Readonly<ConfigureProps>
             or support. Refer to the <Link href="/">Terms and Conditions</Link> guidance for more information.
           </div>
 
+          {study.hraApprovalDate !== null && (
+            <StudyProgressExtended
+              hraApprovalDate={study.hraApprovalDate}
+            />
+          )}
+
           <Form
             action={`/api/forms/configureStudy?returnUrl=${returnUrl}`}
             handleSubmit={handleSubmit}
             method="post"
-            onError={(message: string) =>
-              { setError('root.serverError', { type: '400', message }); }
+            onError={(message: string) => { setError('root.serverError', { type: '400', message }); }
             }
           >
             <input type="hidden" {...register('studyId')} />

--- a/apps/web/src/pages/studies/[studyId]/configure.tsx
+++ b/apps/web/src/pages/studies/[studyId]/configure.tsx
@@ -97,11 +97,11 @@ export default function Configure({ study, returnUrl }: Readonly<ConfigureProps>
             or support. Refer to the <Link href="/">Terms and Conditions</Link> guidance for more information.
           </div>
 
-          {study.hraApprovalDate !== null && (
-            <StudyProgressExtended
-              hraApprovalDate={study.hraApprovalDate}
-            />
-          )}
+          <StudyProgressExtended
+            hraApprovalDate={study.hraApprovalDate}
+            studyStatus={study.studyStatus}
+            willRecruitWithinTimeline={study.willRecruitWithinTimeline}
+          />
 
           <Form
             action={`/api/forms/configureStudy?returnUrl=${returnUrl}`}

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -79,11 +79,6 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
 
   const formStatus = mapCPMSStatusToFormStatus(study.studyStatus) as FormStudyStatus
 
-  const shouldShowStudyProgress =
-    study.hraApprovalDate !== null &&
-    study.willRecruitWithinTimeline &&
-    formStatus === FormStudyStatus.InSetup;
-
   const panelsByStatus: Partial<Record<FormStudyStatus, SummaryCardProps[]>> = {
     [FormStudyStatus.Suspended]: [
       {
@@ -164,10 +159,12 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
               </div>
             )}
 
-            {shouldShowStudyProgress ? <StudyProgressExtended
-                hraApprovalDate={study.hraApprovalDate!}
-                moreDetailsHref={`${STUDIES_PAGE}/${study.id}/configure`}
-              /> : null}
+            <StudyProgressExtended
+              hraApprovalDate={study.hraApprovalDate}
+              moreDetailsHref={`${STUDIES_PAGE}/${study.id}/configure`}
+              studyStatus={study.studyStatus}
+              willRecruitWithinTimeline={study.willRecruitWithinTimeline}
+            />
 
             <div className="flex gap-4">
               <Link className="govuk-button w-auto govuk-!-margin-bottom-0" href={getAssessmentPageRoute(study.id)}>

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 import type { ReactElement } from 'react'
 import type { LeadAdministrationId } from 'shared-utilities/src/utils/lead-administration-id'
+
 import { Status } from '@/@types/studies'
 import type { SummaryCardProps } from '@/components/atoms/SummaryCard/SummaryCard'
 import {
@@ -77,6 +78,11 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
   ).includes(study.studyStatus)
 
   const formStatus = mapCPMSStatusToFormStatus(study.studyStatus) as FormStudyStatus
+
+  const shouldShowStudyProgress =
+    study.hraApprovalDate !== null &&
+    study.willRecruitWithinTimeline &&
+    formStatus === FormStudyStatus.InSetup;
 
   const panelsByStatus: Partial<Record<FormStudyStatus, SummaryCardProps[]>> = {
     [FormStudyStatus.Suspended]: [
@@ -157,13 +163,12 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
                 This study needs a new sponsor assessment.
               </div>
             )}
-            
-            <StudyProgressExtended
-                hraApprovalDate={study.hraApprovalDate}
-                studyStatus={study.studyStatus}
-                willRecruitWithinTimeline={study.willRecruitWithinTimeline}
-            />
-            
+
+            {shouldShowStudyProgress ? <StudyProgressExtended
+                hraApprovalDate={study.hraApprovalDate!}
+                moreDetailsHref={`${STUDIES_PAGE}/${study.id}/configure`}
+              /> : null}
+
             <div className="flex gap-4">
               <Link className="govuk-button w-auto govuk-!-margin-bottom-0" href={getAssessmentPageRoute(study.id)}>
                 Assess study

--- a/apps/web/src/utils/pluralise.ts
+++ b/apps/web/src/utils/pluralise.ts
@@ -3,3 +3,5 @@ export const pluralise = (text: string, totalItems: number) => `${text}${totalIt
 export const pluraliseStudy = (totalItems: number) => (totalItems === 1 ? 'study' : 'studies')
 
 export const pluraliseOrganisation = (totalItems: number) => (totalItems === 1 ? 'organisation' : 'organisations')
+
+export const pluraliseDays = (totalItems: number) => (totalItems === 1 ? 'day' : 'days')


### PR DESCRIPTION
- Updating styling on the progress bar extended element to match the Figma design
- Adding the study progress extended to the opt out page
- Refactoring some of the code around the progress bar 