### PR TITLE
SE-341: Resolve button not working immediately after an action has been completed

### DIFF
--- a/apps/web/src/lib/studies.ts
+++ b/apps/web/src/lib/studies.ts
@@ -518,6 +518,8 @@ export function getDaysSinceAssessmentDue(dueAssessmentAt: Date | null): number 
       : null
 }
 
+const isAssessmentDueIndicator = (indicator: string | undefined) => indicator?.startsWith('Assessment due for')
+
 export function getAssessmentDueIndicator(
   hasAssessmentDue: boolean,
   daysSinceAssessmentDue: number | null
@@ -534,7 +536,7 @@ export function getAssessmentDueIndicator(
 }
 
 function getActionKeyForIndicator(indicator: string): ActionKey | null {
-  if (indicator.startsWith('Assessment due for')) {
+  if (isAssessmentDueIndicator(indicator)) {
     return 'ASSESS_STUDY';
   }
 
@@ -581,6 +583,16 @@ export function buildSummaryRows(indicators: string[], basePath: string) {
 
     grouped.get(actionKey)?.push({ text: indicator });
   });
+
+  // Remove ASSESS_STUDY if an assessment is not due regardless of other indicators
+  const assessTags = grouped.get('ASSESS_STUDY')
+  if (assessTags) {
+    const hasAssessmentDueIndicators = assessTags.some((t) => isAssessmentDueIndicator(t.text))
+    logger.info(hasAssessmentDueIndicators)
+    if (!hasAssessmentDueIndicators) {
+      grouped.delete('ASSESS_STUDY')
+    }
+  }
 
   return Array.from(grouped.entries()).map(([actionKey, tags]) => {
     const { path, actionText } = ACTION_CONFIG[actionKey]

--- a/apps/web/src/pages/studies/[studyId]/index.tsx
+++ b/apps/web/src/pages/studies/[studyId]/index.tsx
@@ -146,7 +146,7 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
     ),
   ].filter(Boolean) as string[];
 
-  const rows = buildSummaryRows(indicators, router.asPath);
+  const indicatorSummaryRows = buildSummaryRows(indicators, `${STUDIES_PAGE}/${study.id}`);
 
   return (
     <Container>
@@ -170,12 +170,12 @@ export default function Study({ study, assessments, editHistory, getEditHistoryE
 
           <div className="flex flex-col govuk-!-margin-bottom-4 govuk-!-margin-top-4 gap-6">
 
-            {indicators.length > 0 && (
+            {indicatorSummaryRows.length > 0 && (
               <>
                 <h3 className="govuk-heading-m govuk-!-margin-bottom-0">
                   Actions needed
                 </h3>
-                <SummaryList rows={rows} className='summary-list--study-indicators govuk-!-margin-bottom-0' />
+                <SummaryList rows={indicatorSummaryRows} className='summary-list--study-indicators govuk-!-margin-bottom-0' />
               </>
             )}
 


### PR DESCRIPTION
- Changing base path to be a static link to the study details page instead of dynamic so that success query parameters don't affect navigation 
-  Logic to remove the assess study row in the indicators summary list if an assessment is not due regardless of other indicators
