### PR TITLE
SE-325: Updating Release Notes Link

### DIFF
--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -96,7 +96,7 @@ export const ACCESSIBILITY_PAGE_URL =
   'https://sites.google.com/nihr.ac.uk/rdncc-policies/sponsor-engagement-tool/set-accessibility-statement'
 
 export const RELEASE_NOTES_URL =
-  'https://sites.google.com/nihr.ac.uk/nihr-sponsor-engagement-tool/se-tool-release-notes'
+  'https://sites.google.com/nihr.ac.uk/rdncc-policies/sponsor-engagement-tool/set-release-notes'
 
 export const SHAW_TRUST_ACCREDITATION_URL =
   'https://www.accessibility-services.co.uk/certificates/nihr-sponsor-engagement-tool/'


### PR DESCRIPTION
In the footer of the SET application, update the url in the hyperlinked text “Release notes” to the RDNCC Policies site for SET instead: 

https://sites.google.com/nihr.ac.uk/rdncc-policies/sponsor-engagement-tool/set-release-notes