### PR TITLE
SE-346: Updating no recruitment label text

### DIFF
--- a/apps/web/src/components/molecules/AssessmentHistory/AssessmentHistory.tsx
+++ b/apps/web/src/components/molecules/AssessmentHistory/AssessmentHistory.tsx
@@ -80,7 +80,7 @@ export function AssessmentHistory({ heading, assessments, firstItemExpanded }: A
 
                   {assessment.reasonForNoRecruitment ? (
                     <p className="govuk-body-s govuk-!-margin-bottom-0">
-                      <strong>Reason for not recruiting for 6 months:</strong>{' '}
+                      <strong>No recruitment for 6 months:</strong>{' '}
                       <span className="whitespace-pre-wrap">{assessment.reasonForNoRecruitment}</span>
                     </p>
                   ) : null}


### PR DESCRIPTION
Change the label ‘Reason for not recruiting for 6 months’ to 'No recruitment for 6 months'